### PR TITLE
Add launch training page

### DIFF
--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -1,0 +1,774 @@
+<?php
+
+require_once '../earthenAuth_helper.php'; // Authentication helper
+
+// PART 1: Set page variables
+$lang = basename(dirname($_SERVER['SCRIPT_NAME']));
+$version = '0.63';
+$page = 'launch-training';
+$lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
+
+ob_start(); // Prevent output before headers
+
+// PART 2: ✅ LOGIN & ROLE CHECK
+if (!isLoggedIn()) {
+    header("Location: login.php");
+    exit();
+}
+
+$buwana_id = $_SESSION['buwana_id'];
+require_once '../gobrikconn_env.php';
+
+// ✅ Fetch User Role
+$gea_status = getGEA_status($buwana_id);
+
+if (!$gea_status || stripos($gea_status, 'trainer') === false) {
+    header("Location: dashboard.php?error=unauthorized");
+    exit();
+}
+
+
+
+
+// PART 3: ✅ Fetch User Details
+require_once '../buwanaconn_env.php';
+$user_continent_icon = getUserContinent($buwana_conn, $buwana_id);
+$earthling_emoji = getUserEarthlingEmoji($buwana_conn, $buwana_id);
+$user_location_watershed = getWatershedName($buwana_conn, $buwana_id);
+$user_location_full = getUserFullLocation($buwana_conn, $buwana_id);
+$user_community_name = getCommunityName($buwana_conn, $buwana_id);
+$first_name = getFirstName($buwana_conn, $buwana_id);
+
+// Fetch all languages
+$languages = [];
+$sql_languages = "SELECT language_id, languages_native_name FROM languages_tb ORDER BY languages_native_name ASC";
+$result_languages = $buwana_conn->query($sql_languages);
+
+if ($result_languages && $result_languages->num_rows > 0) {
+    while ($row = $result_languages->fetch_assoc()) {
+        $languages[] = $row;
+    }
+}
+
+
+
+require_once '../gobrikconn_env.php';
+
+// ✅ Get training_id from URL (for editing)
+$training_id = isset($_GET['training_id']) ? intval($_GET['training_id']) : 0;
+$editing = ($training_id > 0);
+
+// ✅ If editi   ng, fetch existing training details
+if ($editing) {
+    $sql_fetch = "SELECT training_title, lead_trainer, country_id, training_date, no_participants,
+                  training_type, briks_made, avg_brik_weight, location_lat, location_long, training_location,
+                  training_summary, training_agenda, training_success, training_challenges, training_lessons_learned,
+                  youtube_result_video, moodle_url, ready_to_show, featured_description, community_id
+                  FROM tb_trainings WHERE training_id = ?";
+
+    $stmt_fetch = $gobrik_conn->prepare($sql_fetch);
+    $stmt_fetch->bind_param("i", $training_id);
+    $stmt_fetch->execute();
+    $stmt_fetch->bind_result($training_title, $lead_trainer, $country_id, $training_date, $no_participants,
+                            $training_type, $briks_made, $avg_brik_weight, $latitude, $longitude, $training_location,
+                            $training_summary, $training_agenda, $training_success, $training_challenges,
+                            $training_lessons_learned, $youtube_result_video, $moodle_url, $ready_to_show, $featured_description, $community_id);
+    $stmt_fetch->fetch();
+    $stmt_fetch->close();
+}
+
+// ✅ Fetch Unique Training Types
+$training_types = [];
+$result = $gobrik_conn->query("SELECT DISTINCT training_type FROM tb_trainings ORDER BY training_type ASC");
+while ($row = $result->fetch_assoc()) {
+    $training_types[] = $row['training_type'];
+}
+
+// ✅ Fetch List of Countries
+$countries = [];
+$result = $gobrik_conn->query("SELECT country_id, country_name FROM countries_tb ORDER BY country_name ASC");
+while ($row = $result->fetch_assoc()) {
+    $countries[] = $row;
+}
+
+// ✅ Fetch Community Name if Exists
+$community_name = '';
+if (!empty($community_id)) {
+    $stmt = $buwana_conn->prepare("SELECT com_name FROM communities_tb WHERE community_id = ?");
+    $stmt->bind_param("i", $community_id);
+    $stmt->execute();
+    $stmt->bind_result($community_name);
+    $stmt->fetch();
+    $stmt->close();
+}
+
+
+?>
+
+<!--PART 4 GENERATE META TAGS-->
+
+<!DOCTYPE html>
+<HTML lang="en">
+<HEAD>
+    <META charset="UTF-8">
+
+
+<title><?php echo !empty($training_title) ? $training_title : 'Log your Training Report'; ?></title>
+<meta name="keywords" content="GEA Registration, Community, Event, Webinar, Course">
+<meta name="description" content="<?php echo !empty($training_type) && !empty($lead_trainer) && !empty($training_date)
+    ? "Log the $training_type led by $lead_trainer on $training_date on the GEA reporting system. Reports will be shared on the front page of Ecobricks.org."
+    : "Log your GEA workshop. Reports will be featured on the front page of Ecobricks.org and shareable on social media."; ?>">
+
+<!-- Facebook Open Graph Tags for social sharing -->
+<meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/add-report.php">
+<meta property="og:type" content="website">
+<meta property="og:title" content="<meta property="og:title" content="<?php echo !empty($training_title) ? 'Log: ' . $training_title : 'Log your Training Report'; ?>">
+">
+<meta property="og:description" content="<?php echo !empty($training_type) && !empty($lead_trainer) && !empty($training_date)
+    ? "Log the $training_type led by $lead_trainer on $training_date on the GEA reporting system. Reports will be shared on the front page of Ecobricks.org."
+    : "Log your GEA workshop. Reports will be featured on the front page of Ecobricks.org and shareable on social media."; ?>">
+
+<!-- Default image in case no feature image is available -->
+<?php
+$og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobrik.com/svgs/shanti.svg";
+?>
+<meta property="og:image" content="<?php echo $og_image; ?>">
+<meta property="fb:app_id" content="1781710898523821">
+<meta property="og:image:width" content="1000">
+<meta property="og:image:height" content="1000">
+<meta property="og:image:alt" content="<?php echo !empty($training_title) ? $training_title : 'GEA Trainer in action'; ?>">
+<meta property="og:locale" content="en_GB">
+
+<meta property="article:modified_time" content="<?php echo date("c"); ?>">
+
+<meta name="author" content="GoBrik.com">
+<meta property="og:type" content="page">
+<meta property="og:site_name" content="GoBrik.com">
+<meta property="article:publisher" content="https://web.facebook.com/ecobricks.org">
+<meta property="og:image:type" content="image/png">
+<meta name="author" content="GoBrik.com">
+
+<!--PART 5 TOP DECORATION-->
+    <?php require_once ("../includes/launch-training-inc.php");?>
+
+    <div class="splash-content-block"></div>
+    <div id="splash-bar"></div>
+
+    <!-- PAGE CONTENT-->
+
+    <div id="form-submission-box">
+        <div class="form-container">
+            <div class="form-top-header" style="display:flex;flex-flow:row;">
+                <div class="step-graphic" style="width:fit-content;margin:auto;margin-left:0px">
+                    <img src="../svgs/step1-log-project.svg" style="height:25px;">
+                </div>
+                <div id="language-code" onclick="showLangSelector()" aria-label="Switch languages">🌐<span data-lang-id="000-language-code"> EN</span></div>
+            </div>
+
+            <div class="splash-form-content-block">
+                <div class="splash-box">
+                    <div class="splash-heading" data-lang-id="001-splash-title-post">Launch a GEA Training</div>
+                </div>
+                <div class="splash-image" data-lang-id="003-splash-image-alt">
+                    <img src="../svgs/shanti.svg" style="width:65%" alt="GEA trainer in action: File a GEA training report">
+                </div>
+            </div>
+
+            <div class="lead-page-paragraph">
+                <p data-lang-id="004-form-description-post">Use this form to launch a training, workshop or community event on GoBrik.</p>
+            </div>
+
+
+ <!-- PART 6 THE FORM -->
+<form id="submit-form" method="post" action="add-training_process.php" enctype="multipart/form-data" novalidate>
+
+    <div class="form-item" style="margin-top: 25px;">
+        <label for="training_title" data-lang-id="005-title-title">Training Title:</label><br>
+        <input type="text" id="training_title" name="training_title"
+            value="<?php echo htmlspecialchars($training_title ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+            aria-label="Training Title" >
+             <p class="form-caption" data-lang-id="005-training-give-title">Give your training a title.  This will be how your report is featured.</p>
+ <!--ERRORS-->
+                    <div id="title-error-required" class="form-field-error" data-lang-id="000-field-required-error">This field is .</div>
+                    <div id="title-error-long" class="form-field-error" data-lang-id="000-title-field-too-long-error">Your training title is too long. Max 500 characters.</div>
+                    <div id="title-error-invalid" class="form-field-error" data-lang-id="005b-training-title-error">Your entry contains invalid characters. Avoid quotes, slashes, and greater-than signs please.</div>
+        </div>
+
+
+    <div class="form-item">
+    <label for="training_date" datal-lang-id="006-title-date">Training Date:</label><br>
+    <input type="datetime-local" id="training_date" name="training_date"
+    value="<?php echo isset($training_date) ? date('Y-m-d\TH:i', strtotime($training_date)) : date('Y-m-d\T12:00'); ?>"
+    aria-label="Training Date"  class="form-field-style">
+    <p class="form-caption" data-lang-id="006-training-date">On what date and time did this training run?</p>
+    <div id="date-error-required" class="form-field-error" data-lang-id="000-field-required-error" style="display: hidden;">This field is .</div>
+
+</div>
+
+    <div class="form-item">
+        <label for="no_participants" data-lang-id="007-title-participants">Number of Participants:</label><br>
+        <input type="number" id="no_participants" name="no_participants" min="1" max="5000" 
+            value="<?php echo htmlspecialchars($no_participants ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+            <p class="form-caption" data-lang-id="007-training-count">How many people participated (including trainers)?</p>
+            <!--ERRORS-->
+                    <div id="participants-error-required" class="form-field-error" data-lang-id="000-field-required-error">This field is .</div>
+                    <div id="participants-error-range" class="form-field-error" data-lang-id="000-field-participants-number-error">A number (between 1 and 5000).</div>
+             </div>
+
+    <div class="form-item">
+        <label for="lead_trainer" data-lang-id="008-lead-trainer">Lead Trainer:</label><br>
+        <input type="text" id="lead_trainer" name="lead_trainer"
+            value="<?php echo htmlspecialchars($lead_trainer ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+            aria-label="Lead Trainer" >
+            <p class="form-caption" data-lang-id="008-training-trainers">Who lead the training?  You can write multiple names here if you want.  i.e. Lucie Mann and Ani Himawati</p>
+             <!--ERRORS-->
+                    <div id="trainer-error-required" class="form-field-error" data-lang-id="000-field-required-error">This field is .</div>
+                </div>
+
+
+<div class="form-item">
+    <label for="community_search" data-lang-id="009-title-community">Trained Community:</label><br>
+    <input type="text" id="community_search" name="community_search"
+           placeholder="Start typing..." autocomplete="off"
+           value="<?php echo htmlspecialchars($community_name ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+
+    <input type="hidden" id="community_id" name="community_id"
+       value="<?php echo isset($community_id) ? htmlspecialchars($community_id, ENT_QUOTES, 'UTF-8') : ''; ?>">
+
+    <div id="community_results" class="autocomplete-results"></div>
+
+    <!-- "Add a new community" text link
+    <p class="form-caption" data-lang-id="008-community-trained">
+        What community was this training for?  Start typing to see and select a GoBrik community.
+         <a href="#" onclick="openAddCommunityModal(); return false;"
+             style="color: #007BFF; text-decoration: underline;">
+              Don't see your community? Add it.
+          </a>
+    </p>-->
+
+<div id="community-error-required" class="form-field-error" data-lang-id="000-field-too-long-error">A community must be selected</div>
+                </div>
+
+
+
+    <div class="form-item">
+    <label for="training_type" data-lang-id="010-title-type">What type of training was this?</label><br>
+    <select id="training_type" name="training_type"  class="form-field-style">
+        <option value="" disabled selected>Select training type...</option>
+
+        <?php foreach ($training_types as $type): ?>
+            <option value="<?php echo htmlspecialchars($type, ENT_QUOTES, 'UTF-8'); ?>"
+                <?php echo (isset($training_type) && $training_type === $type) ? 'selected' : ''; ?>>
+                <?php echo htmlspecialchars($type, ENT_QUOTES, 'UTF-8'); ?>
+            </option>
+        <?php endforeach; ?>
+    </select>
+   <p class="form-caption" data-lang-id="010-training-type">Please categorize this training.</p>
+   <!--ERROR-->
+                    <div id="type-error-required" class="form-field-error" data-lang-id="000-field-required-error">This field is .</div>
+                </div>
+
+
+  <div class="form-item">
+    <label for="briks_made" data-lang-id="011-title-how-many">How many ecobricks were made?</label><br>
+    <input type="number" id="briks_made" name="briks_made" min="0" max="5000" 
+        value="<?php echo isset($briks_made) ? htmlspecialchars($briks_made, ENT_QUOTES, 'UTF-8') : 0; ?>">
+    <p class="form-caption" data-lang-id="011-how-many-briks">No ecobricks made in this training? Just set at "0" then.</p>
+    <!--ERRORS-->
+                    <div id="briks-error-required" class="form-field-error" data-lang-id="000-field-required-error">This field is .</div>
+                    <div id="briks-error-range" class="form-field-error" data-lang-id="000-field-brik-number-error">Just a number (between 1 and 5000).</div>
+                </div>
+
+<div class="form-item">
+    <label for="avg_brik_weight" data-lang-id="012-title-average">Average Brik Weight (grams):</label><br>
+    <input type="number" id="avg_brik_weight" name="avg_brik_weight" min="0" max="2000" 
+        value="<?php echo isset($avg_brik_weight) ? htmlspecialchars($avg_brik_weight, ENT_QUOTES, 'UTF-8') : 0; ?>">
+        <p class="form-caption" data-lang-id="012-training-average">No ecobricks made in this training? Just set at "0" then.</p>
+         <!--ERRORS-->
+                    <div id="weight-error-range" class="form-field-error" data-lang-id="000-field-weight-number-error">Your estimated average brick weight (in grams) must be a number between 100 and 2000.</div>
+                </div>
+
+<div class="form-item">
+    <label for="country_id" data-lang-id="013-title-country">Country:</label><br>
+    <select id="country_id" name="country_id"  class="form-field-style">
+        <!-- ✅ Ensures placeholder is selected when no country is set -->
+        <option value="" disabled <?php echo empty($country_id) ? 'selected' : ''; ?>>
+            Select a country...
+        </option>
+
+        <?php foreach ($countries as $country): ?>
+            <option value="<?php echo htmlspecialchars($country['country_id'], ENT_QUOTES, 'UTF-8'); ?>"
+                <?php echo (!empty($country_id) && $country_id == $country['country_id']) ? 'selected' : ''; ?>>
+                <?php echo htmlspecialchars($country['country_name'], ENT_QUOTES, 'UTF-8'); ?>
+            </option>
+        <?php endforeach; ?>
+    </select>
+
+    <p class="form-caption" data-lang-id="013-training-country">
+        Where was this training run? If it was an online training, select the country of the lead trainer.
+    </p>
+<!--ERRORS-->
+                    <div id="country-error-required" class="form-field-error" data-lang-id="000-field-required-error">This field is .</div>
+                </div>
+
+
+
+<div class="form-item">
+    <label for="featured_description" data-lang-id="014-feature-description">Featured Description:</label><br>
+    <textarea id="featured_description" name="featured_description"
+              placeholder="Write a compelling description for this training..."
+              rows="5"><?php echo htmlspecialchars($featured_description ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>
+    <p class="form-caption" data-lang-id="014-training-description">This text is shown on the registration page to describe the training. Basic HTML formatting allowed.</p>
+<!--ERRORS-->
+                    <div id="featured-error-required" class="form-field-error" data-lang-id="000-field-required-error">This field is .</div>
+                    <div id="featured-error-long" class="form-field-error" data-lang-id="000-field-summary-too-long-error">Your training summary is too long. Max 255 characters.</div>
+                    <div id="featured-error-invalid" class="form-field-error" data-lang-id="005b-training-summary-error">Your entry contains invalid characters. Avoid quotes, slashes, and greater-than signs.</div>
+                </div>
+
+
+    <div class="form-item">
+        <label for="training_agenda" data-lang-id="015-title-training-agenda">Training Agenda:</label><br>
+        <textarea id="training_agenda" name="training_agenda"><?php echo htmlspecialchars($training_agenda ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>
+            <p class="form-caption" data-lang-id="015-training-agenda">Optional: Please layout the agenda that your training followed. Max 1000 words. You may not need to update this field as it was shown on the registration page to describe the training. Basic HTML formatting allowed.</p>
+<!--ERRORS-->
+                    <div id="agenda-error-long" class="form-field-error" data-lang-id="000-long-field-too-long-error">Your training agenda is too long. Maximum 2000 characters.</div>
+                </div>
+
+<br><br>
+<hr>
+<br>
+
+<div class="form-item">
+    <label for="training_location" data-lang-id="021-title-location">Training Location:</label><br>
+    <input type="text" id="training_location" name="training_location" aria-label="Training Location" 
+        value="<?php echo htmlspecialchars($training_location ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+    <p class="form-caption" data-lang-id="020-location-caption">
+        Please provide the general location where the training was conducted.
+    </p>
+
+     <!--ERRORS-->
+             <div id="location-error-required" class="form-field-error" data-lang-id="000-field-required-error">This field is .</div>
+                </div>
+
+
+<!-- Moodle URL -->
+    <div class="form-item">
+        <label for="moodle_url" data-lang-id="022-title-moodle">Moodle Course URL:</label><br>
+        <input type="url" id="moodle_url" name="moodle_url"
+               value="<?php echo htmlspecialchars($moodle_url ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+               placeholder="Enter Moodle Course Link" class="form-field-style">
+        <p class="form-caption" data-lang-id="022-moodle-caption">
+        Was there a moodle course created for this training on learning.ecobricks.org?  If so, include the URL here.
+    </p>
+
+    </div>
+
+    <!-- YouTube Result Video -->
+    <div class="form-item">
+        <label for="youtube_result_video" data-lang-id="023-title-youtube">YouTube Video URL:</label><br>
+        <input type="url" id="youtube_result_video" name="youtube_result_video"
+               value="<?php echo htmlspecialchars($youtube_result_video ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+               placeholder="Enter YouTube Video URL" class="form-field-style">
+         <p class="form-caption" data-lang-id="023-training-youtube">
+        Was a Youtube video of this training posted?  If so include the URL here pleas.
+    </p>
+    </div>
+
+    <!-- Ready to Show -->
+    <div class="form-item">
+
+        <input type="checkbox" id="ready_to_show" name="ready_to_show" value="1"
+               <?php echo (isset($ready_to_show) && $ready_to_show) ? 'checked' : ''; ?>>
+               <label for="ready_to_show" data-lang-id="024-title-show">🚀 Publish this training publicly?</label><br>
+        <p class="form-caption" data-lang-id="022-training-show">Is this training ready to be displayed on ecobricks.org?  If so, we'll post the completed workshop for to the live feed of GEA trainings.  Don't worry you can always come back here to edit the live listing!</p>
+    </div>
+<input type="hidden" id="training_id" name="training_id" value="<?php echo htmlspecialchars($training_id ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+
+
+<!--     <input type="hidden" id="lat" name="latitude" value="<?php echo htmlspecialchars($latitude ?? '', ENT_QUOTES, 'UTF-8'); ?>"> -->
+<!--     <input type="hidden" id="lon" name="longitude" value="<?php echo htmlspecialchars($longitude ?? '', ENT_QUOTES, 'UTF-8'); ?>"> -->
+
+<div>
+    <input type="submit" value="Next: Upload Photos ➡️" data-lang-id="100-submit-report-1">
+</div>
+
+
+</form>
+
+
+        </div>
+    </div>
+
+
+<!--                <div class="form-item">-->
+<!--                    <label for="connected_ecobricks">The serials of ecobricks used in your project:</label><br>-->
+<!--                    <input type="text" id="connected_ecobricks" name="connected_ecobricks" aria-label="Connected Ecobricks" placeholder="Enter serials...">-->
+<!--                    <div id="serial-select"><ul id="autocomplete-results" ></ul></div>-->
+<!--                    <p class="form-caption">Optional: Enter the serial numbers of ecobricks connected to this project. Separate multiple serial numbers with commas.</p>-->
+<!--                </div>-->
+
+
+
+
+<!-- Load jQuery and Select2 -->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<link href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js"></script>
+
+<!--
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+-->
+
+<script>
+
+
+document.addEventListener("DOMContentLoaded", function() {
+    const communityInput = document.getElementById("community_search");
+    const communityIdField = document.getElementById("community_id");
+    const resultsDiv = document.getElementById("community_results");
+
+    function fetchCommunities(query) {
+        if (query.length >= 3) {
+            fetch(`../api/search_communities.php?query=${encodeURIComponent(query)}`)
+                .then(response => response.json())
+                .then(data => {
+                    resultsDiv.innerHTML = "";
+                    if (data.length === 0) {
+                        resultsDiv.innerHTML = "<div class='autocomplete-item' style='color: gray;'>No results found</div>";
+                    } else {
+                        data.forEach(community => {
+                            let div = document.createElement("div");
+                            div.textContent = community.com_name;
+                            div.dataset.id = community.community_id; // Store the ID
+                            div.classList.add("autocomplete-item");
+
+                            div.addEventListener("mousedown", function(event) {
+                                event.preventDefault();
+                                communityInput.value = community.com_name;
+                                communityIdField.value = community.community_id; // Ensure correct ID is set
+                                resultsDiv.innerHTML = "";
+                                console.log("Selected Community ID: ", community.community_id);
+                            });
+
+                            resultsDiv.appendChild(div);
+                        });
+                    }
+                });
+        } else {
+            resultsDiv.innerHTML = "";
+        }
+    }
+
+    communityInput.addEventListener("input", function() {
+        fetchCommunities(communityInput.value.trim());
+    });
+
+    document.addEventListener("click", function(event) {
+        if (!communityInput.contains(event.target) && !resultsDiv.contains(event.target)) {
+            resultsDiv.innerHTML = "";
+        }
+    });
+});
+
+
+
+
+
+document.getElementById('submit-form').addEventListener('submit', function(event) {
+    event.preventDefault(); // Prevent default form submission
+        var isValid = true;
+    var trainingIdField = document.getElementById('training_id');
+    var trainingId = trainingIdField ? trainingIdField.value.trim() : "";
+
+
+    function displayError(elementId, showError) {
+        var errorDiv = document.getElementById(elementId);
+        if (errorDiv) {
+            errorDiv.style.display = showError ? 'block' : 'none';
+            if (showError) isValid = false;
+        }
+    }
+
+    function hasInvalidChars(value) {
+        const invalidChars = /[<>]/; // Prevents only dangerous characters
+        return invalidChars.test(value);
+    }
+
+    // 🔹 1. Training Title (Max 500 chars)
+    var trainingTitle = document.getElementById('training_title').value.trim();
+//     displayError('title-error-required', trainingTitle === '');
+    displayError('title-error-long', trainingTitle.length > 500);
+    displayError('title-error-invalid', hasInvalidChars(trainingTitle));
+
+    // 🔹 2. Training Date (Required)
+    var trainingDate = document.getElementById('training_date').value.trim();
+//     displayError('date-error-required', trainingDate === '');
+
+    // 🔹 3. Number of Participants (Required, 1 - 5000)
+    var noParticipants = parseInt(document.getElementById('no_participants').value, 10);
+    if (isNaN(noParticipants) || noParticipants === '') {
+//         displayError('participants-error-required', true);
+        displayError('participants-error-range', false);
+    } else if (noParticipants < 1 || noParticipants > 5000) {
+//         displayError('participants-error-required', false);
+        displayError('participants-error-range', true);
+    } else {
+//         displayError('participants-error-required', false);
+        displayError('participants-error-range', false);
+    }
+
+    // 🔹 4. Lead Trainer (Required)
+    var leadTrainer = document.getElementById('lead_trainer').value.trim();
+//     displayError('trainer-error-required', leadTrainer === '');
+
+    // 🔹 5. Training Community (Required)
+    var communityId = document.getElementById('community_id').value.trim();
+//     displayError('community-error-required', communityId === '');
+
+    // 🔹 6. Training Type (Required)
+    var trainingType = document.getElementById('training_type').value;
+//     displayError('type-error-required', trainingType === "");
+
+    // 🔹 7. Briks Made (Min 0)
+    var briksMade = parseInt(document.getElementById('briks_made').value, 10);
+//     displayError('briks-error-required', isNaN(briksMade) || briksMade < 0 || briksMade > 5000);
+
+    // 🔹 8. Average Brik Weight (Min 0)
+    var avgBrikWeight = parseInt(document.getElementById('avg_brik_weight').value, 10);
+//     displayError('weight-error-required', isNaN(avgBrikWeight) || avgBrikWeight < 0 || avgBrikWeight > 2000);
+
+    // 🔹 9. Training Country (Required)
+    var trainingCountry = document.getElementById('country_id').value.trim();
+    // 🔹 14. Training Location (Required)
+    var trainingLocation = document.getElementById('training_location').value.trim();
+//     displayError('location-error-required', trainingLocation === '');
+
+    // 🔹 15. Featured Description (Optional, Max 255 chars)
+    var featuredDescription = document.getElementById('featured_description').value.trim();
+    displayError('featured-error-long', featuredDescription.length > 2000);
+
+    // ✅ Scroll to First Error if any
+    if (!isValid) {
+        var firstError = document.querySelector('.form-field-error:not([style*="display: none"])');
+        if (firstError) {
+            firstError.scrollIntoView({behavior: "smooth", block: "center"});
+            var relatedInput = firstError.closest('.form-item').querySelector('input, select, textarea');
+            if (relatedInput) relatedInput.focus();
+        }
+        return; // Stop execution if validation fails
+    }
+
+    // ✅ Proceed with AJAX Submission
+// ✅ Prepare Form Data for Submission
+    var formData = new FormData(this);
+    var submitButton = document.querySelector('input[type="submit"]');
+    var originalButtonText = submitButton.value;
+    submitButton.value = "Processing...";
+    submitButton.disabled = true;
+
+    fetch(this.action, {
+        method: "POST",
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            var newTrainingId = data.training_id || trainingId; // Use returned ID or existing one
+            window.location.href = "add-training-images.php?training_id=" + newTrainingId;
+        } else {
+            alert("Error: " + (data.error || "An unknown error occurred."));
+            submitButton.value = originalButtonText;
+            submitButton.disabled = false;
+        }
+    })
+    .catch(error => {
+        console.error("Submission error:", error);
+        alert("There was a problem submitting the form.");
+        submitButton.value = originalButtonText;
+        submitButton.disabled = false;
+    });
+});
+
+
+
+
+
+        // Autocomplete serials of ecobricks entered in form
+        $(document).ready(function() {
+            var $serialInput = $('#connected_ecobricks');
+            var $autocompleteResults = $('#autocomplete-results'); // Ensure this UL exists in your HTML
+            var $serialSelect = $('#serial-select'); // Div that contains the autocomplete results
+
+            function performSearch(inputVal) {
+                if (inputVal.length >= 4) { // Ensure there are at least 4 characters to start search
+                    $.ajax({
+                        url: '../get-serials.php',
+                        type: 'GET',
+                        data: { search: inputVal },
+                        success: function(data) {
+                            $autocompleteResults.empty();
+                            if (data.length) {
+                                data.forEach(function(item) {
+                                    $autocompleteResults.append($('<li>').text(item.serial_no));
+                                });
+                                $serialSelect.show(); // Show the suggestions box if there are results
+                            } else {
+                                $autocompleteResults.append($('<li>').text("No results found"));
+                                $serialSelect.hide(); // Hide if no results
+                            }
+                        }
+                    });
+                } else {
+                    $autocompleteResults.empty();
+                    $serialSelect.hide(); // Hide suggestions if less than 4 characters
+                }
+            }
+
+            $serialInput.on('input', function() {
+                var currentValue = $(this).val();
+                var lastTerm = currentValue.split(',').pop().trim(); // Get the last term after a comma
+                performSearch(lastTerm);
+            });
+
+            $autocompleteResults.on('click', 'li', function() {
+                var selectedSerial = $(this).text();
+                var currentInput = $serialInput.val();
+                var lastCommaIndex = currentInput.lastIndexOf(',');
+
+                if (lastCommaIndex === -1) {
+                    // This is the first serial number entry
+                    $serialInput.val(selectedSerial + ', ');
+                } else {
+                    // Replace the last term after the last comma with the selected serial number
+                    var base = currentInput.substring(0, lastCommaIndex + 1);
+                    $serialInput.val(base + ' ' + selectedSerial + ', ');
+                }
+
+                $autocompleteResults.empty();
+                $serialInput.focus(); // Set focus back to input for further entries
+                $serialSelect.hide(); // Hide the autocomplete suggestions box after selection
+            });
+
+            // Optionally hide the autocomplete box when the input loses focus
+            $serialInput.blur(function() {
+                setTimeout(function() { // Timeout to allow click event on suggestions to occur
+                    $serialSelect.hide();
+                }, 200);
+            });
+        });
+
+
+
+
+
+
+
+ function openAddCommunityModal() {
+    const modal = document.getElementById('form-modal-message');
+    const modalBox = document.getElementById('modal-content-box');
+
+    modal.style.display = 'flex';
+    modalBox.style.flexFlow = 'column';
+    document.getElementById('page-content')?.classList.add('blurred');
+    document.getElementById('footer-full')?.classList.add('blurred');
+    document.body.classList.add('modal-open');
+
+    modalBox.style.maxHeight = '80vh';
+    modalBox.style.overflowY = 'auto';
+
+    modalBox.innerHTML = `
+        <h2 style="text-align:center;">Add Your Community</h2>
+        <p>Add your community to GoBrik so you can manage local projects and ecobricks.</p>
+
+        <form id="addCommunityForm" onsubmit="addCommunity2Buwana(event)">
+            <label for="newCommunityName">Name of Community:</label>
+            <input type="text" id="newCommunityName" name="newCommunityName" >
+
+            <label for="newCommunityType">Type of Community:</label>
+            <select id="newCommunityType" name="newCommunityType" >
+                <option value="">Select Type</option>
+                <option value="neighborhood">Neighborhood</option>
+                <option value="city">City</option>
+                <option value="school">School</option>
+                <option value="organization">Organization</option>
+            </select>
+
+            <label for="communityCountry">Country:</label>
+            <select id="communityCountry" name="communityCountry" >
+                <option value="">Select Country</option>
+                <?php foreach ($countries as $country) : ?>
+                    <option value="<?php echo $country['country_id']; ?>">
+                        <?php echo htmlspecialchars($country['country_name'], ENT_QUOTES, 'UTF-8'); ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+
+            <label for="communityLanguage">Preferred Language:</label>
+            <select id="communityLanguage" name="communityLanguage" >
+                <option value="">Select Language</option>
+                <?php foreach ($languages as $language) : ?>
+                    <option value="<?php echo $language['language_id']; ?>">
+                        <?php echo htmlspecialchars($language['languages_native_name'], ENT_QUOTES, 'UTF-8'); ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+
+            <button type="submit" style="margin-top:10px;width:100%;" class="submit-button enabled">Submit</button>
+        </form>
+    `;
+}
+
+
+function addCommunity2Buwana(event) {
+    event.preventDefault(); // Prevent normal form submission
+
+    const form = document.getElementById('addCommunityForm');
+    const formData = new FormData(form);
+
+    fetch('../scripts/add_community.php', {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        alert(data.message); // Show success or error message
+
+        if (data.success) {
+            // Close modal
+            closeInfoModal();
+
+            // Add the new community to the dropdown
+            const communityInput = document.getElementById('community_name');
+            const communityList = document.getElementById('community_list');
+
+            // Create new option
+            const newOption = document.createElement('option');
+            newOption.value = data.community_name;
+            newOption.textContent = data.community_name;
+            communityList.appendChild(newOption);
+
+            // Set selected value
+            communityInput.value = data.community_name;
+        }
+    })
+    .catch(error => {
+        alert('Error adding community. Please try again.');
+        console.error('Error:', error);
+    });
+}
+
+
+
+    </script>
+
+    <br><br>
+    </div> <!--closes main-->
+
+    <!--FOOTER STARTS HERE-->
+    <?php require_once ("../footer-2025.php");?>
+    </div>
+
+    </body>
+</html>

--- a/includes/launch-training-inc.php
+++ b/includes/launch-training-inc.php
@@ -1,0 +1,407 @@
+
+
+
+  
+<STYLE>
+
+
+
+.form-item input {
+  background: var(--input-background) !important;
+  font-size: 1.5em;
+}
+
+.form-field-style {
+  width: 100%;
+  padding: 9px 11px !important;
+  margin: 4px 0;
+  font-size: 20px !important;
+  box-sizing: border-box;
+  border: 3px solid var(--button-2-1);
+  border-radius: 5px;
+  background-color: var(--top-header);
+   border: 1px solid var(--button-2-1) !important;
+}
+
+
+.advanced-box-content {
+    padding: 2px 15px 15px 15px;
+    max-height: 0;  /* Initially set to 0 */
+    overflow: hidden;  /* Hide any overflowing content */
+    transition: max-height 0.5s ease-in-out;  /* Transition effect */
+	font-size:smaller;
+	margin-top:-10px;
+}
+
+
+.dropdown {
+  float: right;
+  overflow: hidden;
+  margin-bottom: -10px;
+}
+
+#registration-footer {
+
+  display:none !important;
+}
+
+#serial-select ul {
+  list-style: none;
+  padding: 0;
+}
+
+
+.form-item li:hover {
+  background: var(--emblem-blue);
+  cursor: pointer;
+  padding:3px;
+}
+
+#serial-select {
+  background: var(--advanced-background);
+  width: 130px;
+  margin-top: -10px;
+  padding: 10px 10px 10px 20px;
+  border-radius: 0px 0px 10px 10px;
+  position: absolute;
+  z-index: 100;
+  margin-left: 15px;
+  display: none;
+}
+
+.splash-image {display:flex;}
+
+.splash-image img {margin-right: auto; margin-left: 0px;}
+
+
+@media screen and (max-width: 700px) { 
+	.splash-content-block {  
+        background-color: var(--top-header);
+        filter: none !important;
+        min-height: 20vh !important;
+        height: 20vh !important;
+        
+	}
+
+  .splash-image {display: none !important;}
+
+  /* .splash-image img  {height: 200px;} */
+}
+
+
+@media screen and (min-width: 700px) { 
+	.splash-content-block {
+        background-color: var(--top-header);
+        filter: none !important;
+        min-height: 20vh !important;
+}
+} 
+
+@media screen and (max-width: 700px) {
+.splash-heading {
+	font-size: 2.5em !important;
+	line-height: 1.1;
+	margin: 10px 0px;
+	text-align: center;
+}
+}
+
+@media screen and (min-width: 700px) {
+.splash-heading {
+	font-size: 3.1em !important;
+}
+}
+
+#splash-bar {
+
+    background-color: var(--top-header);
+    filter: none !important;
+    margin-bottom: -200px !important;
+
+}
+
+#main-background {
+  background-size: cover;
+
+}
+
+#main {
+  background-color: #0003 !important;
+}
+
+/*  
+#form-submission-box {
+  font-family: "Mulish", sans-serif;
+} */
+
+/* h2 {
+  font-family: "Arvo", serif;
+  color: var(--h1);
+} */
+
+.form-item {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+.form-caption {
+  font-family: "Mulish", sans-serif;
+  font-weight: 300;
+  color: var(--text-color);
+  font-size: 1.0em;
+  margin-top: -5px;
+}
+
+
+
+label {
+  font-family: "Mulish", sans-serif;
+  font-weight: 500;
+  color: var(--text-color);
+  font-size: 1.3em;
+}
+
+
+.form-item input {
+  background: var(--input-background);
+  font-size: 1.3em;
+}
+
+.form-item textarea {
+  background: var(--input-background);
+  font-size: 1.3em;
+}
+
+.form-item select {
+  background: var(--input-background);
+  font-size: 1.2em;
+  padding: 5px;
+  border-radius: 5px;
+  margin-top: 9px;
+  margin-bottom: 10px;
+}
+
+input[type="text"],
+input[type="number"],
+textarea,
+input[type="date"] {
+  font-family: "Mulish", sans-serif;
+  font-weight: 300;
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  border: 1px solid var(--divider-line);
+  border-radius: 5px;
+  box-sizing: border-box;
+  margin-top: 8px;
+
+}
+
+input[type="submit"] {
+  color: white;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background-color: #12b712; /* Initial background color */
+  background-size: 0% 100%; /* Initial background size (progress bar) */
+  transition: background-size 0.5s ease; /* Transition effect for smooth progress */
+  font-size: 1.3em;
+  width: 100%;
+  margin-top: 30px;
+}
+
+/* Specify the progress bar color */
+input[type="submit"].progress-bar {
+  background: url(../svgs/square-upload-progress.svg) left center repeat-y, gray; /* Combined background */
+  background-size: auto; /* Auto size for image background */
+}
+
+
+input[type="submit"]:hover {
+  background-color: green;
+} 
+
+.spinner-photo-loading {
+    border: 4px solid rgba(0, 0, 0, 0.1);
+    border-left-color: #ffffff;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+
+
+.form-field-error {
+  color: red;
+  margin-top: -15px;
+  margin-bottom: 20px;
+  padding-left: 10px;
+  padding-bottom: 15px;
+  display: none;
+}
+
+.form-container {
+
+  width: 80%;
+  background-color: var(--form-background);
+  border: 1px solid var(--divider-line);
+  border-radius: 15px;
+  margin: 0 auto;
+  max-width: 1000px;
+  z-index: 20;
+  font-family: "Mulish", sans-serif;
+  position: relative;
+
+}
+
+/* Media Query for screens under 700px */
+@media screen and (max-width: 700px) {
+  .form-container {
+    width: calc(100% - 40px);
+    margin: 0;
+    /* border: none; */
+    padding: 20px 20px 0 20px;
+    max-width: 600px;
+    padding: 20px;
+    position: relative;
+    margin-top: 60px;
+
+  }
+}
+
+#featured_image {
+  margin-bottom: 8px;
+  margin-top: 8px;
+  padding: 5px;
+  font-size: 1em;
+}
+
+#tmb_featured_image {
+  margin-bottom: 8px;
+  margin-top: 8px;
+  padding: 5px;
+  font-size: 1em;
+}
+
+/* Centering the form vertically on larger screens */
+@media screen and (min-width: 701px) {
+  /* #form-submission-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+  } */
+
+  .form-container {
+    margin-top: auto;
+    margin-bottom: auto;
+    padding: 30px;
+    margin-top: 100px;
+
+  }
+}
+
+.module-btn {
+  background: var(--emblem-green);
+  width: 100%;
+  display: flex;
+}
+	
+.module-btn:hover {
+  background: var(--emblem-green-over);
+}
+	
+.confirm-button {
+  color: white;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  background: var(--emblem-green);
+  font-size: 1.3em;
+  margin: auto;
+  justify-content: center;
+  text-align: center;
+  text-decoration: none;
+  margin-top: 10px;
+  display: flex;
+}
+
+.confirm-button:hover {
+  background: var(--emblem-green-over);
+
+
+}
+
+
+/*upload*/
+
+.form-item {
+    border-radius: 5px;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 10px;
+    background-color: #00000015;
+}
+
+.form-item label,
+.form-item input,
+.form-item .form-caption {
+    padding: 10px;
+}
+
+#photos-submission-box .form-item input {
+    font-size: 1.2em;
+    color: var(--text-color);
+    border-radius: 5px;
+    background-color: #ffffff35;
+    margin-top: 10px;
+    cursor: pointer;
+}
+
+.form-item .form-caption {
+    font-size: 1.0;
+
+
+}
+.input-container {
+    position: relative;
+    display: inline-block;
+    width: 100%
+}
+
+#location_address {
+    width: 100%;
+    padding-right: 30px; /* Make space for the spinner */
+}
+
+.spinner {
+    display: none;
+    position: absolute;
+    top: 30%;  /* Center vertically in the input field */
+    right: 15px; /* Distance from the right edge of the input field */
+    transform: translateY(-50%); /* Ensures the spinner is exactly centered vertically */
+    width: 20px;
+    height: 20px;
+    border: 4px solid rgba(0,0,0,0.1);
+    border-top: 4px solid var(--emblem-pink);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); translateY(-50%); }
+    100% { transform: rotate(360deg); translateY(-50%); }
+}
+
+
+
+</style>	
+
+<?php require_once ("../header-2024.php");?>

--- a/meta/launch-training-en.php
+++ b/meta/launch-training-en.php
@@ -1,0 +1,18 @@
+<title>Launch a GEA Training | GoBrik</title>
+<meta name="keywords" content="GEA, training, launch, event, workshop">
+<meta name="description" content="Use GoBrik to launch a GEA training, workshop or community event.">
+<meta name="author" content="Global Ecobrick Alliance">
+<meta name="last-modified" content="' . $lastModified . '">
+<meta name="revised" content="' . $lastModified . '">
+<!-- Facebook Open Graph Tags for social sharing-->
+<meta http-equiv="content-type" content="text/html; charset=UTF-8" >
+<meta property="og:url" content="https://www.gobrik.com/' . $lang . '/launch-training.php">
+<meta property="og:type" content="form">
+<meta property="og:title" content="Launch a GEA Training">
+<meta property="og:description" content="Use GoBrik to launch a GEA training, workshop or community event.">
+<meta property="og:image" content="https://gobrik.com/svgs/shanti.svg">
+<meta property="fb:app_id" content="1781710898523821" >
+<meta property="og:image:width" content="1000" >
+<meta property="og:image:height" content="1000" >
+<meta property="og:image:alt" content="GEA trainer in action">
+<meta property="og:locale" content="en_GB">

--- a/meta/launch-training-es.php
+++ b/meta/launch-training-es.php
@@ -1,0 +1,18 @@
+<title>Lanzar una Capacitación GEA | GoBrik</title>
+<meta name="keywords" content="GEA, capacitación, lanzar, evento, taller">
+<meta name="description" content="Usa GoBrik para lanzar una capacitación, taller o evento comunitario de la GEA.">
+<meta name="author" content="Global Ecobrick Alliance">
+<meta name="last-modified" content="' . $lastModified . '">
+<meta name="revised" content="' . $lastModified . '">
+<!-- Facebook Open Graph Tags for social sharing-->
+<meta http-equiv="content-type" content="text/html; charset=UTF-8" >
+<meta property="og:url" content="https://www.gobrik.com/' . $lang . '/launch-training.php">
+<meta property="og:type" content="form">
+<meta property="og:title" content="Lanzar una Capacitación GEA">
+<meta property="og:description" content="Usa GoBrik para lanzar una capacitación, taller o evento comunitario de la GEA.">
+<meta property="og:image" content="https://gobrik.com/svgs/shanti.svg">
+<meta property="fb:app_id" content="1781710898523821" >
+<meta property="og:image:width" content="1000" >
+<meta property="og:image:height" content="1000" >
+<meta property="og:image:alt" content="Entrenador de GEA en acción">
+<meta property="og:locale" content="es_ES">

--- a/meta/launch-training-fr.php
+++ b/meta/launch-training-fr.php
@@ -1,0 +1,18 @@
+<title>Lancer une Formation GEA | GoBrik</title>
+<meta name="keywords" content="GEA, formation, lancer, événement, atelier">
+<meta name="description" content="Utilisez GoBrik pour lancer une formation, un atelier ou un événement communautaire GEA.">
+<meta name="author" content="Global Ecobrick Alliance">
+<meta name="last-modified" content="' . $lastModified . '">
+<meta name="revised" content="' . $lastModified . '">
+<!-- Facebook Open Graph Tags for social sharing-->
+<meta http-equiv="content-type" content="text/html; charset=UTF-8" >
+<meta property="og:url" content="https://www.gobrik.com/' . $lang . '/launch-training.php">
+<meta property="og:type" content="form">
+<meta property="og:title" content="Lancer une Formation GEA">
+<meta property="og:description" content="Utilisez GoBrik pour lancer une formation, un atelier ou un événement communautaire GEA.">
+<meta property="og:image" content="https://gobrik.com/svgs/shanti.svg">
+<meta property="fb:app_id" content="1781710898523821" >
+<meta property="og:image:width" content="1000" >
+<meta property="og:image:height" content="1000" >
+<meta property="og:image:alt" content="Formateur GEA en action">
+<meta property="og:locale" content="fr_FR">

--- a/meta/launch-training-id.php
+++ b/meta/launch-training-id.php
@@ -1,0 +1,18 @@
+<title>Luncurkan Pelatihan GEA | GoBrik</title>
+<meta name="keywords" content="GEA, pelatihan, luncurkan, acara, lokakarya">
+<meta name="description" content="Gunakan GoBrik untuk meluncurkan pelatihan, lokakarya atau acara komunitas GEA.">
+<meta name="author" content="Global Ecobrick Alliance">
+<meta name="last-modified" content="' . $lastModified . '">
+<meta name="revised" content="' . $lastModified . '">
+<!-- Facebook Open Graph Tags for social sharing-->
+<meta http-equiv="content-type" content="text/html; charset=UTF-8" >
+<meta property="og:url" content="https://www.gobrik.com/' . $lang . '/launch-training.php">
+<meta property="og:type" content="form">
+<meta property="og:title" content="Luncurkan Pelatihan GEA">
+<meta property="og:description" content="Gunakan GoBrik untuk meluncurkan pelatihan, lokakarya atau acara komunitas GEA.">
+<meta property="og:image" content="https://gobrik.com/svgs/shanti.svg">
+<meta property="fb:app_id" content="1781710898523821" >
+<meta property="og:image:width" content="1000" >
+<meta property="og:image:height" content="1000" >
+<meta property="og:image:alt" content="Pelatih GEA beraksi">
+<meta property="og:locale" content="id_ID">

--- a/translations/launching-training-en.js
+++ b/translations/launching-training-en.js
@@ -1,0 +1,43 @@
+/*-----------------------------------
+
+English SNIPPETS FOR launch-training page on GoBrik
+
+-----------------------------------*/
+const en_Page_Translations = {
+    "000-language-code": "EN",
+    "000-field-required-error":"This field is required.",
+    "001-splash-title-post": "Launch a GEA Training",
+    "003-splash-image-alt":'<img src="../svgs/shanti.svg" style="width:65%" alt="GEA trainer in action: File a GEA training report">',
+    "004-form-description-post": "Use this form to launch a training, workshop or community event on GoBrik.",
+    "005-title-title":"Training Title:",
+    "005-training-give-title": "Give your training a title.  This will be how your report is featured.",
+    "006-title-date":"Training Date:",
+    "006-training-date":"On what date and time will this training run?",
+    "007-title-participants": "Number of Participants:",
+    "007-training-count": "How many people are expected to participate (including trainers)?",
+    "008-lead-trainer": "Lead Trainer:",
+    "008-training-trainers": "Who will lead the training? You can write multiple names here if you want. i.e. Lucie Mann and Ani Himawati",
+    "009-title-community": "Trained Community:",
+    "008-community-trained": "What community is this training for? Start typing to see and select a GoBrik community. <a href=\"#\" onclick=\"openAddCommunityModal(); return false;\" style=\"color: #007BFF; text-decoration: underline;\">Don't see your community? Add it.</a>",
+    "010-title-type": "What type of training is this?",
+    "010-training-type": "Please categorize this training.",
+    "011-title-how-many": "How many ecobricks will be made?",
+    "011-how-many-briks": "No ecobricks planned? Just set at \"0\" then.",
+    "012-title-average": "Average Brik Weight (grams):",
+    "012-training-average": "No ecobricks planned? Just set at \"0\" then.",
+    "013-title-country": "Country:",
+    "013-training-country": "Where will this training run? If it is an online training, select the country of the lead trainer.",
+    "014-feature-description": "Featured Description:",
+    "014-training-description": "This text is shown on the registration page to describe the training. Basic HTML formatting allowed.",
+    "015-training-title-agenda": "Training Agenda:",
+    "015-training-agenda": "Optional: Please layout the agenda that your training will follow. Max 1000 words. Basic HTML formatting allowed.",
+    "021-title-location": "Training Location:",
+    "020-location-caption": "Please provide the general location where the training will be conducted.",
+    "022-title-moodle": "Moodle Course URL:",
+    "022-moodle-caption": "Was there a Moodle course created for this training on learning.ecobricks.org? If so, include the URL here.",
+    "023-title-youtube": "YouTube Video URL:",
+    "023-training-youtube": "Is there a YouTube video for this training? If so, include the URL here please.",
+    "024-title-show": "🚀 Publish this training publicly?",
+    "022-training-show": "Is this training ready to be displayed on ecobricks.org?  If so, we'll post the listing once submitted. Don't worry you can always come back here to edit!",
+    "100-submit-report-1": "Next: Upload Photos ➡️"
+};

--- a/translations/launching-training-es.js
+++ b/translations/launching-training-es.js
@@ -1,0 +1,31 @@
+/*-----------------------------------
+
+Spanish SNIPPETS FOR launch-training page on GoBrik
+
+-----------------------------------*/
+const es_Page_Translations = {
+    "000-language-code": "ES",
+    "000-field-required-error": "Este campo es obligatorio.",
+    "001-splash-title-post": "Lanzar una capacitación GEA",
+    "003-splash-image-alt": '<img src="../svgs/shanti.svg" style="width:65%" alt="Entrenador de GEA en acción: Presentar un informe de formación de GEA">',
+    "004-form-description-post": "Usa este formulario para lanzar una capacitación, taller o evento comunitario en GoBrik.",
+    "005-title-title": "Título de la capacitación:",
+    "005-training-give-title": "Dale un título a tu capacitación. Así se mostrará tu informe.",
+    "006-title-date": "Fecha de la capacitación:",
+    "006-training-date": "¿En qué fecha y hora será esta capacitación?",
+    "007-title-participants": "Número de participantes:",
+    "007-training-count": "¿Cuántas personas participarán (incluidos los formadores)?",
+    "008-lead-trainer": "Formador principal:",
+    "008-training-trainers": "¿Quién dirigirá la capacitación? Puedes escribir varios nombres aquí si es necesario, por ejemplo, Lucie Mann y Ani Himawati.",
+    "009-title-community": "Comunidad capacitada:",
+    "008-community-trained": "¿Para qué comunidad es esta capacitación? Empieza a escribir para ver y seleccionar una comunidad de GoBrik. <a href=\"#\" onclick=\"openAddCommunityModal(); return false;\" style=\"color: #007BFF; text-decoration: underline;\">¿No ves tu comunidad? Agrégala.</a>",
+    "010-title-type": "Tipo de capacitación:",
+    "010-training-type": "Por favor, categoriza esta capacitación.",
+    "011-title-how-many": "¿Cuántos ecoladrillos se harán?",
+    "011-how-many-briks": "¿No se harán ecoladrillos en esta capacitación? Simplemente pon \"0\".",
+    "012-title-average": "Peso promedio del ecoladrillo (gramos):",
+    "012-training-average": "¿No se harán ecoladrillos en esta capacitación? Simplemente pon \"0\".",
+    "013-title-country": "País:",
+    "013-training-country": "¿Dónde se realizará esta capacitación? Si es en línea, selecciona el país del formador principal.",
+    "100-submit-report-1": "Siguiente: Subir fotos ➡️"
+};

--- a/translations/launching-training-fr.js
+++ b/translations/launching-training-fr.js
@@ -1,0 +1,43 @@
+/*-----------------------------------
+
+French SNIPPETS FOR launch-training page on GoBrik
+
+-----------------------------------*/
+const fr_Page_Translations = {
+    "000-language-code": "FR",
+    "000-field-required-error": "Ce champ est requis.",
+    "001-splash-title-post": "Lancer une formation GEA",
+    "003-splash-image-alt": '<img src="../svgs/shanti.svg" style="width:65%" alt="Formateur GEA en action : Soumettre un rapport de formation GEA">',
+    "004-form-description-post": "Utilisez ce formulaire pour lancer une formation, un atelier ou un événement communautaire sur GoBrik.",
+    "005-title-title": "Titre de la formation :",
+    "005-training-give-title": "Donnez un titre à votre formation. C'est ainsi que votre rapport sera présenté.",
+    "006-title-date": "Date de la formation :",
+    "006-training-date": "À quelle date et heure cette formation aura-t-elle lieu ?",
+    "007-title-participants": "Nombre de participants :",
+    "007-training-count": "Combien de personnes participeront (y compris les formateurs) ?",
+    "008-lead-trainer": "Formateur principal :",
+    "008-training-trainers": "Qui dirigera la formation ? Vous pouvez écrire plusieurs noms ici si nécessaire, par exemple, Lucie Mann et Ani Himawati.",
+    "009-title-community": "Communauté formée :",
+    "008-community-trained": "Pour quelle communauté cette formation est-elle prévue ? Commencez à taper pour voir et sélectionner une communauté GoBrik. <a href=\"#\" onclick=\"openAddCommunityModal(); return false;\" style=\"color: #007BFF; text-decoration: underline;\">Vous ne trouvez pas votre communauté ? Ajoutez-la.</a>",
+    "010-title-type": "Type de formation :",
+    "010-training-type": "Veuillez catégoriser cette formation.",
+    "011-title-how-many": "Combien d'écobriques seront fabriquées ?",
+    "011-how-many-briks": "Aucune écobrique prévue ? Indiquez simplement \"0\".",
+    "012-title-average": "Poids moyen des écobriques (grammes) :",
+    "012-training-average": "Aucune écobrique prévue ? Indiquez simplement \"0\".",
+    "013-title-country": "Pays :",
+    "013-training-country": "Où cette formation aura-t-elle lieu ? Si c'est une formation en ligne, sélectionnez le pays du formateur principal.",
+    "014-feature-description": "Description en vedette :",
+    "014-training-description": "Ce texte est affiché sur la page d'inscription pour décrire la formation. Formatage HTML basique autorisé.",
+    "015-training-title-agenda": "Agenda de la formation :",
+    "015-training-agenda": "Facultatif : veuillez présenter l'agenda suivi pendant votre formation. Maximum 1000 mots. Formatage HTML basique autorisé.",
+    "021-title-location": "Lieu de la formation :",
+    "020-location-caption": "Veuillez indiquer l'emplacement général où la formation aura lieu.",
+    "022-title-moodle": "URL du cours Moodle :",
+    "022-moodle-caption": "Un cours Moodle a-t-il été créé pour cette formation sur learning.ecobricks.org ? Si oui, incluez l'URL ici.",
+    "023-title-youtube": "URL de la vidéo YouTube :",
+    "023-training-youtube": "Y a-t-il une vidéo YouTube pour cette formation ? Si oui, incluez l'URL ici.",
+    "024-title-show": "Publier cette formation publiquement ?",
+    "022-training-show": "Cette formation est-elle prête à être affichée sur ecobricks.org ? Si oui, nous publierons la liste une fois soumise. Ne vous inquiétez pas, vous pourrez toujours revenir ici pour la modifier !",
+    "100-submit-report-1": "Suivant : Télécharger les photos ➡️"
+};

--- a/translations/launching-training-id.js
+++ b/translations/launching-training-id.js
@@ -1,0 +1,43 @@
+/*-----------------------------------
+
+Indonesian SNIPPETS FOR launch-training page on GoBrik
+
+-----------------------------------*/
+const id_Page_Translations = {
+    "000-language-code": "ID",
+    "000-field-required-error": "Kolom ini wajib diisi.",
+    "001-splash-title-post": "Luncurkan Pelatihan GEA",
+    "003-splash-image-alt": '<img src="../svgs/shanti.svg" style="width:65%" alt="Pelatih GEA dalam aksi: Unggah laporan pelatihan GEA">',
+    "004-form-description-post": "Gunakan formulir ini untuk meluncurkan pelatihan, lokakarya atau acara komunitas di GoBrik.",
+    "005-title-title": "Judul Pelatihan:",
+    "005-training-give-title": "Beri judul pada pelatihan Anda. Ini akan menjadi cara laporan Anda ditampilkan.",
+    "006-title-date": "Tanggal Pelatihan:",
+    "006-training-date": "Pada tanggal dan waktu berapa pelatihan ini berlangsung?",
+    "007-title-participants": "Jumlah Peserta:",
+    "007-training-count": "Berapa banyak orang yang akan berpartisipasi (termasuk pelatih)?",
+    "008-lead-trainer": "Pelatih Utama:",
+    "008-training-trainers": "Siapa yang memimpin pelatihan? Anda dapat menuliskan beberapa nama di sini jika diperlukan, misalnya, Lucie Mann dan Ani Himawati.",
+    "009-title-community": "Komunitas yang Dilatih:",
+    "008-community-trained": "Komunitas mana yang mengikuti pelatihan ini? Mulai mengetik untuk melihat dan memilih komunitas GoBrik. <a href=\"#\" onclick=\"openAddCommunityModal(); return false;\" style=\"color: #007BFF; text-decoration: underline;\">Tidak melihat komunitas Anda? Tambahkan.</a>",
+    "010-title-type": "Jenis Pelatihan:",
+    "010-training-type": "Silakan kategorikan jenis pelatihan ini.",
+    "011-title-how-many": "Berapa banyak ecobrick yang akan dibuat?",
+    "011-how-many-briks": "Tidak ada ecobrick yang dibuat? Atur ke \"0\" saja.",
+    "012-title-average": "Berat Rata-rata Brik (gram):",
+    "012-training-average": "Tidak ada ecobrick yang dibuat? Atur ke \"0\" saja.",
+    "013-title-country": "Negara:",
+    "013-training-country": "Di mana pelatihan ini dilaksanakan? Jika ini adalah pelatihan online, pilih negara pelatih utama.",
+    "014-feature-description": "Deskripsi Unggulan:",
+    "014-training-description": "Teks ini ditampilkan di halaman pendaftaran untuk mendeskripsikan pelatihan. Format HTML dasar diperbolehkan.",
+    "015-training-title-agenda": "Agenda Pelatihan:",
+    "015-training-agenda": "Opsional: Harap susun agenda yang diikuti dalam pelatihan Anda. Maksimal 1000 kata. Format HTML dasar diperbolehkan.",
+    "021-title-location": "Lokasi Pelatihan:",
+    "020-location-caption": "Harap berikan lokasi umum di mana pelatihan ini diadakan.",
+    "022-title-moodle": "URL Kursus Moodle:",
+    "022-moodle-caption": "Apakah ada kursus Moodle untuk pelatihan ini di learning.ecobricks.org? Jika ada, masukkan URL di sini.",
+    "023-title-youtube": "URL Video YouTube:",
+    "023-training-youtube": "Apakah ada video YouTube untuk pelatihan ini? Jika ada, silakan masukkan URL di sini.",
+    "024-title-show": "Publikasikan pelatihan ini secara publik?",
+    "022-training-show": "Apakah pelatihan ini siap ditampilkan di ecobricks.org? Jika ya, kami akan mempublikasikan daftar tersebut setelah dikirim. Jangan khawatir, Anda selalu dapat kembali untuk mengeditnya!",
+    "100-submit-report-1": "Lanjut: Unggah Foto ➡️"
+};


### PR DESCRIPTION
## Summary
- add new launch-training.php page for trainers to list upcoming trainings
- duplicate styles via launch-training-inc.php
- provide meta tags for launch-training in EN, ES, ID and FR
- include language files for launch-training in EN, ES, ID and FR

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68411aa07cc88323bc4353870d5d08c6