### PR TITLE
Add trainer search tags and remove brik fields

### DIFF
--- a/api/search_trainers.php
+++ b/api/search_trainers.php
@@ -1,0 +1,20 @@
+<?php
+require_once '../gobrikconn_env.php';
+header('Content-Type: application/json');
+$trainers = [];
+if (isset($_GET['query'])) {
+    $query = '%' . trim($_GET['query']) . '%';
+    $sql = "SELECT ecobricker_id, full_name FROM tb_ecobrickers WHERE gea_status LIKE '%trainer%' AND full_name LIKE ? ORDER BY full_name ASC LIMIT 10";
+    if ($stmt = $gobrik_conn->prepare($sql)) {
+        $stmt->bind_param('s', $query);
+        $stmt->execute();
+        $stmt->bind_result($id, $name);
+        while ($stmt->fetch()) {
+            $trainers[] = ['ecobricker_id' => $id, 'full_name' => $name];
+        }
+        $stmt->close();
+    }
+}
+echo json_encode($trainers);
+$gobrik_conn->close();
+?>

--- a/includes/launch-training-inc.php
+++ b/includes/launch-training-inc.php
@@ -395,6 +395,29 @@ input[type="submit"]:hover {
     animation: spin 1s linear infinite;
 }
 
+.trainer-tag-container {
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: 5px;
+}
+
+.trainer-tag-box {
+    display: flex;
+    align-items: center;
+    background: #ccc;
+    border-radius: 15px;
+    padding: 2px 8px;
+    margin: 2px;
+    font-size: 0.9em;
+}
+
+.trainer-tag-box .remove-trainer {
+    margin-right: 6px;
+    cursor: pointer;
+    color: #fff;
+    font-weight: bold;
+}
+
 @keyframes spin {
     0% { transform: rotate(0deg); translateY(-50%); }
     100% { transform: rotate(360deg); translateY(-50%); }

--- a/meta/launch-training-en.php
+++ b/meta/launch-training-en.php
@@ -1,4 +1,4 @@
-<title>Launch a GEA Training | GoBrik</title>
+<title>Launch a Training | GoBrik</title>
 <meta name="keywords" content="GEA, training, launch, event, workshop">
 <meta name="description" content="Use GoBrik to launch a GEA training, workshop or community event.">
 <meta name="author" content="Global Ecobrick Alliance">
@@ -8,7 +8,7 @@
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" >
 <meta property="og:url" content="https://www.gobrik.com/' . $lang . '/launch-training.php">
 <meta property="og:type" content="form">
-<meta property="og:title" content="Launch a GEA Training">
+<meta property="og:title" content="Launch a Training">
 <meta property="og:description" content="Use GoBrik to launch a GEA training, workshop or community event.">
 <meta property="og:image" content="https://gobrik.com/svgs/shanti.svg">
 <meta property="fb:app_id" content="1781710898523821" >


### PR DESCRIPTION
## Summary
- convert trainer select to searchable tag input in launch training form
- hide removed brik and youtube fields using hidden inputs
- add trainer tag styling
- allow ajax search for trainers
- update page title meta info

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684126dac86c8323805a0955e356138d