### PR TITLE
Fix launch training meta includes

### DIFF
--- a/meta/launch-training-en.php
+++ b/meta/launch-training-en.php
@@ -6,10 +6,9 @@
     : "Launch your GEA training, event, webinar or workshop. Trainings will be featured on the front page of Ecobricks.org and shareable on social media."; ?>">
 
 <!-- Facebook Open Graph Tags for social sharing -->
-<meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/add-report.php">
+<meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/launch-training.php">
 <meta property="og:type" content="website">
-<meta property="og:title" content="<meta property="og:title" content="<?php echo !empty($training_title) ? $training_title : 'Launch your GEA training!'; ?>">
-">
+<meta property="og:title" content="<?php echo !empty($training_title) ? $training_title : 'Launch your GEA training!'; ?>">
 <meta property="og:description" content="<?php echo !empty($training_type) && !empty($lead_trainer) && !empty($training_date)
                                              ? "Launch, list and manage the $training_type led by $lead_trainer on $training_date on GoBrik. Trainings will be featuring publicly for user registration once launched."
                                              : "Launch your GEA training, event, webinar or workshop. Trainings will be featured on the front page of Ecobricks.org and shareable on social media."; ?>">
@@ -32,4 +31,3 @@ $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobri
 <meta property="og:site_name" content="GoBrik.com">
 <meta property="article:publisher" content="https://web.facebook.com/ecobricks.org">
 <meta property="og:image:type" content="image/png">
-<meta name="author" content="GoBrik.com">

--- a/meta/launch-training-es.php
+++ b/meta/launch-training-es.php
@@ -1,18 +1,29 @@
-<title>Lanzar una Capacitación GEA | GoBrik</title>
+<title><?php echo !empty($training_title) ? $training_title : 'Lanzar una Capacitación GEA'; ?></title>
 <meta name="keywords" content="GEA, capacitación, lanzar, evento, taller">
-<meta name="description" content="Usa GoBrik para lanzar una capacitación, taller o evento comunitario de la GEA.">
-<meta name="author" content="Global Ecobrick Alliance">
-<meta name="last-modified" content="' . $lastModified . '">
-<meta name="revised" content="' . $lastModified . '">
-<!-- Facebook Open Graph Tags for social sharing-->
-<meta http-equiv="content-type" content="text/html; charset=UTF-8" >
-<meta property="og:url" content="https://www.gobrik.com/' . $lang . '/launch-training.php">
-<meta property="og:type" content="form">
-<meta property="og:title" content="Lanzar una Capacitación GEA">
-<meta property="og:description" content="Usa GoBrik para lanzar una capacitación, taller o evento comunitario de la GEA.">
-<meta property="og:image" content="https://gobrik.com/svgs/shanti.svg">
-<meta property="fb:app_id" content="1781710898523821" >
-<meta property="og:image:width" content="1000" >
-<meta property="og:image:height" content="1000" >
-<meta property="og:image:alt" content="Entrenador de GEA en acción">
+<meta name="description" content="<?php echo !empty($training_type) && !empty($lead_trainer) && !empty($training_date)
+    ? "Lanza, lista y administra el $training_type dirigido por $lead_trainer el $training_date en GoBrik. Las capacitaciones se mostrarán públicamente para el registro de usuarios una vez lanzadas."
+    : "Usa GoBrik para lanzar una capacitación, taller o evento comunitario de la GEA."; ?>">
+
+<!-- Facebook Open Graph Tags for social sharing -->
+<meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/launch-training.php">
+<meta property="og:type" content="website">
+<meta property="og:title" content="<?php echo !empty($training_title) ? $training_title : 'Lanzar una Capacitación GEA'; ?>">
+<meta property="og:description" content="<?php echo !empty($training_type) && !empty($lead_trainer) && !empty($training_date)
+                                             ? "Lanza, lista y administra el $training_type dirigido por $lead_trainer el $training_date en GoBrik. Las capacitaciones se mostrarán públicamente para el registro de usuarios una vez lanzadas."
+                                             : "Usa GoBrik para lanzar una capacitación, taller o evento comunitario de la GEA."; ?>">
+
+<?php
+$og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobrik.com/svgs/shanti.svg";
+?>
+<meta property="og:image" content="<?php echo $og_image; ?>">
+<meta property="fb:app_id" content="1781710898523821">
+<meta property="og:image:width" content="1000">
+<meta property="og:image:height" content="1000">
+<meta property="og:image:alt" content="<?php echo !empty($training_title) ? $training_title : 'Entrenador de GEA en acción'; ?>">
 <meta property="og:locale" content="es_ES">
+<meta property="article:modified_time" content="<?php echo date('c'); ?>">
+<meta name="author" content="GoBrik.com">
+<meta property="og:type" content="page">
+<meta property="og:site_name" content="GoBrik.com">
+<meta property="article:publisher" content="https://web.facebook.com/ecobricks.org">
+<meta property="og:image:type" content="image/png">

--- a/meta/launch-training-fr.php
+++ b/meta/launch-training-fr.php
@@ -1,18 +1,29 @@
-<title>Lancer une Formation GEA | GoBrik</title>
+<title><?php echo !empty($training_title) ? $training_title : 'Lancer une Formation GEA'; ?></title>
 <meta name="keywords" content="GEA, formation, lancer, événement, atelier">
-<meta name="description" content="Utilisez GoBrik pour lancer une formation, un atelier ou un événement communautaire GEA.">
-<meta name="author" content="Global Ecobrick Alliance">
-<meta name="last-modified" content="' . $lastModified . '">
-<meta name="revised" content="' . $lastModified . '">
-<!-- Facebook Open Graph Tags for social sharing-->
-<meta http-equiv="content-type" content="text/html; charset=UTF-8" >
-<meta property="og:url" content="https://www.gobrik.com/' . $lang . '/launch-training.php">
-<meta property="og:type" content="form">
-<meta property="og:title" content="Lancer une Formation GEA">
-<meta property="og:description" content="Utilisez GoBrik pour lancer une formation, un atelier ou un événement communautaire GEA.">
-<meta property="og:image" content="https://gobrik.com/svgs/shanti.svg">
-<meta property="fb:app_id" content="1781710898523821" >
-<meta property="og:image:width" content="1000" >
-<meta property="og:image:height" content="1000" >
-<meta property="og:image:alt" content="Formateur GEA en action">
+<meta name="description" content="<?php echo !empty($training_type) && !empty($lead_trainer) && !empty($training_date)
+    ? "Lancez, répertoriez et gérez le $training_type dirigé par $lead_trainer le $training_date sur GoBrik. Les formations seront présentées publiquement pour l'inscription une fois lancées."
+    : "Utilisez GoBrik pour lancer une formation, un atelier ou un événement communautaire GEA."; ?>">
+
+<!-- Facebook Open Graph Tags for social sharing -->
+<meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/launch-training.php">
+<meta property="og:type" content="website">
+<meta property="og:title" content="<?php echo !empty($training_title) ? $training_title : 'Lancer une Formation GEA'; ?>">
+<meta property="og:description" content="<?php echo !empty($training_type) && !empty($lead_trainer) && !empty($training_date)
+                                             ? "Lancez, répertoriez et gérez le $training_type dirigé par $lead_trainer le $training_date sur GoBrik. Les formations seront présentées publiquement pour l'inscription une fois lancées."
+                                             : "Utilisez GoBrik pour lancer une formation, un atelier ou un événement communautaire GEA."; ?>">
+
+<?php
+$og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobrik.com/svgs/shanti.svg";
+?>
+<meta property="og:image" content="<?php echo $og_image; ?>">
+<meta property="fb:app_id" content="1781710898523821">
+<meta property="og:image:width" content="1000">
+<meta property="og:image:height" content="1000">
+<meta property="og:image:alt" content="<?php echo !empty($training_title) ? $training_title : 'Formateur GEA en action'; ?>">
 <meta property="og:locale" content="fr_FR">
+<meta property="article:modified_time" content="<?php echo date('c'); ?>">
+<meta name="author" content="GoBrik.com">
+<meta property="og:type" content="page">
+<meta property="og:site_name" content="GoBrik.com">
+<meta property="article:publisher" content="https://web.facebook.com/ecobricks.org">
+<meta property="og:image:type" content="image/png">

--- a/meta/launch-training-id.php
+++ b/meta/launch-training-id.php
@@ -1,18 +1,29 @@
-<title>Luncurkan Pelatihan GEA | GoBrik</title>
+<title><?php echo !empty($training_title) ? $training_title : 'Luncurkan Pelatihan GEA'; ?></title>
 <meta name="keywords" content="GEA, pelatihan, luncurkan, acara, lokakarya">
-<meta name="description" content="Gunakan GoBrik untuk meluncurkan pelatihan, lokakarya atau acara komunitas GEA.">
-<meta name="author" content="Global Ecobrick Alliance">
-<meta name="last-modified" content="' . $lastModified . '">
-<meta name="revised" content="' . $lastModified . '">
-<!-- Facebook Open Graph Tags for social sharing-->
-<meta http-equiv="content-type" content="text/html; charset=UTF-8" >
-<meta property="og:url" content="https://www.gobrik.com/' . $lang . '/launch-training.php">
-<meta property="og:type" content="form">
-<meta property="og:title" content="Luncurkan Pelatihan GEA">
-<meta property="og:description" content="Gunakan GoBrik untuk meluncurkan pelatihan, lokakarya atau acara komunitas GEA.">
-<meta property="og:image" content="https://gobrik.com/svgs/shanti.svg">
-<meta property="fb:app_id" content="1781710898523821" >
-<meta property="og:image:width" content="1000" >
-<meta property="og:image:height" content="1000" >
-<meta property="og:image:alt" content="Pelatih GEA beraksi">
+<meta name="description" content="<?php echo !empty($training_type) && !empty($lead_trainer) && !empty($training_date)
+    ? "Luncurkan, daftar, dan kelola $training_type yang dipimpin oleh $lead_trainer pada $training_date di GoBrik. Pelatihan akan ditampilkan secara publik untuk pendaftaran pengguna setelah diluncurkan."
+    : "Gunakan GoBrik untuk meluncurkan pelatihan, lokakarya atau acara komunitas GEA."; ?>">
+
+<!-- Facebook Open Graph Tags for social sharing -->
+<meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/launch-training.php">
+<meta property="og:type" content="website">
+<meta property="og:title" content="<?php echo !empty($training_title) ? $training_title : 'Luncurkan Pelatihan GEA'; ?>">
+<meta property="og:description" content="<?php echo !empty($training_type) && !empty($lead_trainer) && !empty($training_date)
+                                             ? "Luncurkan, daftar, dan kelola $training_type yang dipimpin oleh $lead_trainer pada $training_date di GoBrik. Pelatihan akan ditampilkan secara publik untuk pendaftaran pengguna setelah diluncurkan."
+                                             : "Gunakan GoBrik untuk meluncurkan pelatihan, lokakarya atau acara komunitas GEA."; ?>">
+
+<?php
+$og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobrik.com/svgs/shanti.svg";
+?>
+<meta property="og:image" content="<?php echo $og_image; ?>">
+<meta property="fb:app_id" content="1781710898523821">
+<meta property="og:image:width" content="1000">
+<meta property="og:image:height" content="1000">
+<meta property="og:image:alt" content="<?php echo !empty($training_title) ? $training_title : 'Pelatih GEA beraksi'; ?>">
 <meta property="og:locale" content="id_ID">
+<meta property="article:modified_time" content="<?php echo date('c'); ?>">
+<meta name="author" content="GoBrik.com">
+<meta property="og:type" content="page">
+<meta property="og:site_name" content="GoBrik.com">
+<meta property="article:publisher" content="https://web.facebook.com/ecobricks.org">
+<meta property="og:image:type" content="image/png">


### PR DESCRIPTION
## Summary
- clean up meta tags for launch training pages
- dynamically generate meta in English
- update Spanish, French and Indonesian meta files to match

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68412b898b988323b63ac97ef7c4ecbf