### PR TITLE
Add feature_photo3 support and redesign launch toggle

### DIFF
--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -62,6 +62,7 @@ $zoom_link = '';
 $zoom_link_full = '';
 $feature_photo1_main = '';
 $feature_photo2_main = '';
+$feature_photo3_main = '';
 $registration_scope = '';
 $trainer_contact_email = '';
 
@@ -71,7 +72,7 @@ if ($editing) {
                   training_type, training_language, briks_made, avg_brik_weight, location_lat, location_long, training_location,
                   training_summary, training_agenda, training_success, training_challenges, training_lessons_learned,
                   youtube_result_video, moodle_url, ready_to_show, featured_description, community_id,
-                  zoom_link, zoom_link_full, feature_photo1_main, feature_photo2_main, registration_scope, trainer_contact_email
+                  zoom_link, zoom_link_full, feature_photo1_main, feature_photo2_main, feature_photo3_main, registration_scope, trainer_contact_email
                   FROM tb_trainings WHERE training_id = ?";
 
     $stmt_fetch = $gobrik_conn->prepare($sql_fetch);
@@ -81,7 +82,7 @@ if ($editing) {
                             $training_type, $training_language, $briks_made, $avg_brik_weight, $latitude, $longitude, $training_location,
                             $training_summary, $training_agenda, $training_success, $training_challenges,
                             $training_lessons_learned, $youtube_result_video, $moodle_url, $ready_to_show, $featured_description, $community_id,
-                            $zoom_link, $zoom_link_full, $feature_photo1_main, $feature_photo2_main, $registration_scope, $trainer_contact_email);
+                            $zoom_link, $zoom_link_full, $feature_photo1_main, $feature_photo2_main, $feature_photo3_main, $registration_scope, $trainer_contact_email);
     $stmt_fetch->fetch();
     $stmt_fetch->close();
 }
@@ -390,6 +391,12 @@ if (!empty($community_id)) {
     </div>
 
     <div class="form-item">
+        <label for="feature_photo3_main">Set a third training photo</label><br>
+        <input type="file" id="feature_photo3_main" name="feature_photo3_main" class="form-field-style">
+        <p class="form-caption">This image will also be visible in the training registration page.</p>
+    </div>
+
+    <div class="form-item">
         <label for="registration_scope">Registration scope</label><br>
         <select id="registration_scope" name="registration_scope" class="form-field-style">
             <option value="trainers" <?php echo (isset($registration_scope) && $registration_scope=='trainers') ? 'selected' : ''; ?>>Trainers only</option>
@@ -406,15 +413,18 @@ if (!empty($community_id)) {
     </div>
 
     <!-- Ready to Show -->
-    <div class="form-item">
-
-        <label class="toggle-switch">
-            <input type="checkbox" id="ready_to_show" name="ready_to_show" value="1"
-                   <?php echo (isset($ready_to_show) && $ready_to_show) ? 'checked' : ''; ?>>
-            <span class="slider"></span>
-        </label>
-        <label class="toggle-description" for="ready_to_show" data-lang-id="024-title-show">Launch this training</label><br>
-        <p class="form-caption" data-lang-id="022-training-show">Is this training ready to be displayed on ecobricks.org?  If so, we'll post the completed workshop for to the live feed of GEA trainings.  Don't worry you can always come back here to edit the live listing!</p>
+    <div class="form-item form-row">
+        <div class="toggle-left">
+            <label class="toggle-switch">
+                <input type="checkbox" id="ready_to_show" name="ready_to_show" value="1"
+                       <?php echo (isset($ready_to_show) && $ready_to_show) ? 'checked' : ''; ?>>
+                <span class="slider"></span>
+            </label>
+        </div>
+        <div class="toggle-right">
+            <label class="toggle-description" for="ready_to_show" data-lang-id="024-title-show">Launch this training</label>
+            <p class="form-caption" data-lang-id="022-training-show">Is this training ready to be displayed on ecobricks.org?  If so, we'll post the completed workshop for to the live feed of GEA trainings.  Don't worry you can always come back here to edit the live listing!</p>
+        </div>
     </div>
 <input type="hidden" id="training_id" name="training_id" value="<?php echo htmlspecialchars($training_id ?? '', ENT_QUOTES, 'UTF-8'); ?>">
 
@@ -870,6 +880,7 @@ Schedule
 
     setFileInputFromUrl('feature_photo1_main', 'https://gobrik.com/webps/starter-workshop-feature-1-en.webp');
     setFileInputFromUrl('feature_photo2_main', 'https://gobrik.com/webps/starter-workshop-feature-2-en.webp');
+    setFileInputFromUrl('feature_photo3_main', 'https://gobrik.com/webps/starter-workshop-feature-3-en.webp');
 }
 
 document.getElementById('starterPresetBtn')?.addEventListener('click', presetForStarterWorkshop);

--- a/en/launch-training_process.php
+++ b/en/launch-training_process.php
@@ -130,7 +130,7 @@ if ($editing) {
     $fields = [];
     $values = [];
     $types = '';
-    for ($i = 1; $i <= 2; $i++) {
+    for ($i = 1; $i <= 3; $i++) {
         $name = "feature_photo{$i}_main";
         if (isset($_FILES[$name]) && $_FILES[$name]['error'] == UPLOAD_ERR_OK) {
             $file = "training-{$new_training_id}-feature{$i}.webp";
@@ -183,7 +183,7 @@ if ($editing) {
     $fields = [];
     $values = [];
     $types = '';
-    for ($i = 1; $i <= 2; $i++) {
+    for ($i = 1; $i <= 3; $i++) {
         $name = "feature_photo{$i}_main";
         if (isset($_FILES[$name]) && $_FILES[$name]['error'] == UPLOAD_ERR_OK) {
             $file = "training-{$new_training_id}-feature{$i}.webp";

--- a/styles/main.css
+++ b/styles/main.css
@@ -2266,6 +2266,23 @@ input[type="date"] {
     background-color: #00000015;
 }
 
+.form-row {
+    display: flex;
+    flex-flow: row;
+    align-items: center;
+}
+
+.form-row .toggle-left {
+    width: 60px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.form-row .toggle-right {
+    flex: 1;
+}
+
 .form-item label,
 .form-item input,
 .form-item .form-caption {


### PR DESCRIPTION
## Summary
- allow third feature photo on launch-training form and SQL fetch
- adjust training launch toggle to use a two-column layout
- expand photo loops in launch-training_process.php to handle third photo
- add styling for the new two-column toggle layout

## Testing
- `php -l en/launch-training.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684158285be483239621ec3f2c381bcd