### PR TITLE
Add preview for training feature images

### DIFF
--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -414,9 +414,9 @@ if (!empty($community_id)) {
     <!-- ======================= Feature Photo 1 ======================= -->
     <div class="form-item">
         <label for="feature_photo1_main">Set Feature Photo</label><br>
-        <?php if (!empty($feature_photo1_main)) : ?>
-            <img src="<?php echo htmlspecialchars($feature_photo1_main, ENT_QUOTES, 'UTF-8'); ?>" style="max-width:350px;max-height:200px;" alt="Feature Photo 1 Preview"><br>
-        <?php endif; ?>
+        <div id="feature_photo1_preview" style="background:#ccc;width:350px;height:200px;margin-bottom:5px;display:none;">
+            <img id="feature_photo1_preview_img" src="" style="max-width:100%;max-height:100%;object-fit:contain;" alt="Feature Photo 1 Preview">
+        </div>
         <input type="url" id="feature_photo1_main" name="feature_photo1_main" class="form-field-style" value="<?php echo htmlspecialchars($feature_photo1_main ?? '', ENT_QUOTES, 'UTF-8'); ?>">
         <p class="form-caption">
             This is the image that will be used to list your training on GoBrik.
@@ -426,9 +426,9 @@ if (!empty($community_id)) {
     <!-- ======================= Feature Photo 2 ======================= -->
     <div class="form-item">
         <label for="feature_photo2_main">Set a Second Training Feature Photo</label><br>
-        <?php if (!empty($feature_photo2_main)) : ?>
-            <img src="<?php echo htmlspecialchars($feature_photo2_main, ENT_QUOTES, 'UTF-8'); ?>" style="max-width:350px;max-height:200px;" alt="Feature Photo 2 Preview"><br>
-        <?php endif; ?>
+        <div id="feature_photo2_preview" style="background:#ccc;width:350px;height:200px;margin-bottom:5px;display:none;">
+            <img id="feature_photo2_preview_img" src="" style="max-width:100%;max-height:100%;object-fit:contain;" alt="Feature Photo 2 Preview">
+        </div>
         <input type="url" id="feature_photo2_main" name="feature_photo2_main" class="form-field-style" value="<?php echo htmlspecialchars($feature_photo2_main ?? '', ENT_QUOTES, 'UTF-8'); ?>">
         <p class="form-caption">
             This image will be visible on the training registration page.
@@ -438,9 +438,9 @@ if (!empty($community_id)) {
     <!-- ======================= Feature Photo 3 ======================= -->
     <div class="form-item">
         <label for="feature_photo3_main">Set a Third Training Feature Photo</label><br>
-        <?php if (!empty($feature_photo3_main)) : ?>
-            <img src="<?php echo htmlspecialchars($feature_photo3_main, ENT_QUOTES, 'UTF-8'); ?>" style="max-width:350px;max-height:200px;" alt="Feature Photo 3 Preview"><br>
-        <?php endif; ?>
+        <div id="feature_photo3_preview" style="background:#ccc;width:350px;height:200px;margin-bottom:5px;display:none;">
+            <img id="feature_photo3_preview_img" src="" style="max-width:100%;max-height:100%;object-fit:contain;" alt="Feature Photo 3 Preview">
+        </div>
         <input type="url" id="feature_photo3_main" name="feature_photo3_main" class="form-field-style" value="<?php echo htmlspecialchars($feature_photo3_main ?? '', ENT_QUOTES, 'UTF-8'); ?>">
         <p class="form-caption">
             This image will also be visible on the training registration page.
@@ -861,6 +861,9 @@ function setFileInputFromUrl(inputId, url) {
     const input = document.getElementById(inputId);
     if (input) {
         input.value = url;
+        const imgId = inputId + '_preview_img';
+        const containerId = inputId + '_preview';
+        updateImagePreview(inputId, imgId, containerId);
     }
 }
 
@@ -920,6 +923,34 @@ Schedule
 }
 
 document.getElementById('starterPresetBtn')?.addEventListener('click', presetForStarterWorkshop);
+
+function updateImagePreview(inputId, imgId, containerId) {
+    const input = document.getElementById(inputId);
+    const img = document.getElementById(imgId);
+    const container = document.getElementById(containerId);
+    if (input && img && container) {
+        const url = input.value.trim();
+        if (url) {
+            img.src = url;
+            container.style.display = 'block';
+        } else {
+            img.src = '';
+            container.style.display = 'none';
+        }
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    ['feature_photo1_main','feature_photo2_main','feature_photo3_main'].forEach(function(id) {
+        const imgId = id + '_preview_img';
+        const containerId = id + '_preview';
+        const input = document.getElementById(id);
+        if (input) {
+            input.addEventListener('input', function() { updateImagePreview(id, imgId, containerId); });
+            updateImagePreview(id, imgId, containerId); // initial
+        }
+    });
+});
 
 
 


### PR DESCRIPTION
## Summary
- show preview boxes for feature photos
- add JS to update previews when image URL is entered
- ensure preset button updates preview

## Testing
- `php -l en/launch-training.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68418f9984b88323a455db7408d414d3