### PR TITLE
Dynamic training id and meta for register page

### DIFF
--- a/en/register.php
+++ b/en/register.php
@@ -8,8 +8,8 @@ $page = 'register';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 $is_logged_in = isLoggedIn(); // Check if the user is logged in
 
-// Define training ID at the top
-$training_id = 818; // Ensure this is defined before any queries
+// Get training ID from the URL
+$training_id = isset($_GET['id']) ? intval($_GET['id']) : 0;
 
 // Initialize training variables
 $training_title = $training_date = $lead_trainer = "";
@@ -82,9 +82,6 @@ if ($result->num_rows > 0) {
     $training_logged = htmlspecialchars($row['training_logged'], ENT_QUOTES, 'UTF-8');
     $lead_trainer = htmlspecialchars($row['lead_trainer'], ENT_QUOTES, 'UTF-8');
     $training_type = htmlspecialchars($row['training_type'], ENT_QUOTES, 'UTF-8');
-    $briks_made = $row['briks_made'];
-    $avg_brik_weight = $row['avg_brik_weight'];
-    $est_plastic_packed = $row['est_plastic_packed'];
     $training_country = htmlspecialchars($row['training_country'], ENT_QUOTES, 'UTF-8');
     $training_location = htmlspecialchars($row['training_location'], ENT_QUOTES, 'UTF-8');
     $registration_scope = htmlspecialchars($row['registration_scope'], ENT_QUOTES, 'UTF-8');
@@ -94,13 +91,17 @@ if ($result->num_rows > 0) {
     $training_challenges = nl2br(htmlspecialchars($row['training_challenges'], ENT_QUOTES, 'UTF-8'));
     $training_lessons_learned = nl2br(htmlspecialchars($row['training_lessons_learned'], ENT_QUOTES, 'UTF-8'));
     $training_url = htmlspecialchars($row['training_url'], ENT_QUOTES, 'UTF-8');
-    $connected_ecobricks = nl2br(htmlspecialchars($row['connected_ecobricks'], ENT_QUOTES, 'UTF-8'));
     $ready_to_show = $row['ready_to_show'];
 
     // ✅ Fetch feature photos
     $feature_photo1_main = htmlspecialchars($row['feature_photo1_main'], ENT_QUOTES, 'UTF-8');
     $feature_photo2_main = htmlspecialchars($row['feature_photo2_main'], ENT_QUOTES, 'UTF-8');
     $feature_photo1_tmb = htmlspecialchars($row['feature_photo1_tmb'], ENT_QUOTES, 'UTF-8');
+
+    if ($ready_to_show == 0) {
+        echo "<script>alert('Sorry this training isn\'t yet listed for public registration.'); window.location.href='trainings.php';</script>";
+        exit;
+    }
 }
 
 
@@ -116,30 +117,6 @@ echo '<!DOCTYPE html>
 ';
 ?>
 
-<title><?php echo $training_title; ?></title>
-<meta name="keywords" content="GEA Registration, Community, Event, Webinar, Course">
-<meta name="description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
-
-<!-- Facebook Open Graph Tags for social sharing -->
-<meta property="og:url" content="https://www.gobrik.com/en/register.php">
-<meta property="og:type" content="website">
-<meta property="og:title" content="<?php echo $training_title; ?>">
-<meta property="og:description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
-<meta property="og:image" content="<?php echo !empty($feature_photo1_main) ? $feature_photo1_main : '../photos/events/terraces-forests-gladys.jpg'; ?>">
-<meta property="fb:app_id" content="1781710898523821">
-<meta property="og:image:width" content="1000">
-<meta property="og:image:height" content="500">
-<meta property="og:image:alt" content="<?php echo $training_title; ?>">
-<meta property="og:locale" content="en_GB">
-
-<meta property="article:modified_time" content="<?php echo date("c"); ?>">
-
-<meta name="author" content="GoBrik.com">
-<meta property="og:type" content="page">
-<meta property="og:site_name" content="GoBrik.com">
-<meta property="article:publisher" content="https://web.facebook.com/ecobricks.org">
-<meta property="og:image:type" content="image/png">
-<meta name="author" content="GoBrik.com">
 
 
 <!-- Page CSS & JS Initialization -->

--- a/includes/register-inc.php
+++ b/includes/register-inc.php
@@ -8,7 +8,7 @@
 <link rel="preload" as="image" href="../webps/biosphere2.webp">
 <link rel="preload" as="image" href="../webps/biosphere-day.webp">-->
 
-
+<?php require_once ("../meta/register-$lang.php");?>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 

--- a/meta/register-es.php
+++ b/meta/register-es.php
@@ -1,19 +1,19 @@
 <title><?php echo $training_title; ?></title>
-<meta name="keywords" content="GEA Registration, Community, Event, Webinar, Course">
-<meta name="description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
+<meta name="keywords" content="Registro GEA, Evento comunitario, Webinar, Curso">
+<meta name="description" content="Regístrese para nuestro <?php echo $training_type; ?> dirigido por <?php echo $lead_trainer; ?> el <?php echo $training_date; ?>">
 
 <!-- Facebook Open Graph Tags for social sharing -->
 <meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/register.php?id=<?php echo $training_id; ?>">
 <meta property="og:type" content="website">
 <meta property="og:title" content="<?php echo $training_title; ?>">
-<meta property="og:description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
+<meta property="og:description" content="Regístrese para nuestro <?php echo $training_type; ?> dirigido por <?php echo $lead_trainer; ?> el <?php echo $training_date; ?>">
 <?php $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : 'https://www.gobrik.com/photos/events/terraces-forests-gladys.jpg'; ?>
 <meta property="og:image" content="<?php echo $og_image; ?>">
 <meta property="fb:app_id" content="1781710898523821">
 <meta property="og:image:width" content="1000">
 <meta property="og:image:height" content="500">
 <meta property="og:image:alt" content="<?php echo $training_title; ?>">
-<meta property="og:locale" content="en_GB">
+<meta property="og:locale" content="es_ES">
 <meta property="article:modified_time" content="<?php echo date('c'); ?>">
 <meta name="author" content="GoBrik.com">
 <meta property="og:type" content="page">

--- a/meta/register-fr.php
+++ b/meta/register-fr.php
@@ -1,19 +1,19 @@
 <title><?php echo $training_title; ?></title>
-<meta name="keywords" content="GEA Registration, Community, Event, Webinar, Course">
-<meta name="description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
+<meta name="keywords" content="Inscription GEA, Événement communautaire, Webinaire, Cours">
+<meta name="description" content="Inscrivez-vous à notre <?php echo $training_type; ?> animé par <?php echo $lead_trainer; ?> le <?php echo $training_date; ?>">
 
 <!-- Facebook Open Graph Tags for social sharing -->
 <meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/register.php?id=<?php echo $training_id; ?>">
 <meta property="og:type" content="website">
 <meta property="og:title" content="<?php echo $training_title; ?>">
-<meta property="og:description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
+<meta property="og:description" content="Inscrivez-vous à notre <?php echo $training_type; ?> animé par <?php echo $lead_trainer; ?> le <?php echo $training_date; ?>">
 <?php $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : 'https://www.gobrik.com/photos/events/terraces-forests-gladys.jpg'; ?>
 <meta property="og:image" content="<?php echo $og_image; ?>">
 <meta property="fb:app_id" content="1781710898523821">
 <meta property="og:image:width" content="1000">
 <meta property="og:image:height" content="500">
 <meta property="og:image:alt" content="<?php echo $training_title; ?>">
-<meta property="og:locale" content="en_GB">
+<meta property="og:locale" content="fr_FR">
 <meta property="article:modified_time" content="<?php echo date('c'); ?>">
 <meta name="author" content="GoBrik.com">
 <meta property="og:type" content="page">

--- a/meta/register-id.php
+++ b/meta/register-id.php
@@ -1,19 +1,19 @@
 <title><?php echo $training_title; ?></title>
-<meta name="keywords" content="GEA Registration, Community, Event, Webinar, Course">
-<meta name="description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
+<meta name="keywords" content="Pendaftaran GEA, Acara komunitas, Webinar, Kursus">
+<meta name="description" content="Daftar untuk <?php echo $training_type; ?> yang dipimpin oleh <?php echo $lead_trainer; ?> pada <?php echo $training_date; ?>">
 
 <!-- Facebook Open Graph Tags for social sharing -->
 <meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/register.php?id=<?php echo $training_id; ?>">
 <meta property="og:type" content="website">
 <meta property="og:title" content="<?php echo $training_title; ?>">
-<meta property="og:description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
+<meta property="og:description" content="Daftar untuk <?php echo $training_type; ?> yang dipimpin oleh <?php echo $lead_trainer; ?> pada <?php echo $training_date; ?>">
 <?php $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : 'https://www.gobrik.com/photos/events/terraces-forests-gladys.jpg'; ?>
 <meta property="og:image" content="<?php echo $og_image; ?>">
 <meta property="fb:app_id" content="1781710898523821">
 <meta property="og:image:width" content="1000">
 <meta property="og:image:height" content="500">
 <meta property="og:image:alt" content="<?php echo $training_title; ?>">
-<meta property="og:locale" content="en_GB">
+<meta property="og:locale" content="id_ID">
 <meta property="article:modified_time" content="<?php echo date('c'); ?>">
 <meta name="author" content="GoBrik.com">
 <meta property="og:type" content="page">


### PR DESCRIPTION
## Summary
- load page meta via register-inc
- get training id from URL
- check readiness before showing page
- centralize register page meta per language

## Testing
- `php -l en/register.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6842736a2900832386eabaa3e4ddfdac