### PR TITLE
Fix warnings on register page and use training images

### DIFF
--- a/en/register.php
+++ b/en/register.php
@@ -77,26 +77,27 @@ if ($result->num_rows > 0) {
     $allowed_tags = '<b><i><u><strong><em><p><br><ul><li><ol>';
     $training_summary = strip_tags($row['training_summary'] ?? '', $allowed_tags);
     $training_agenda = strip_tags($row['training_agenda'] ?? '', $allowed_tags);
-    $training_title = htmlspecialchars($row['training_title'], ENT_QUOTES, 'UTF-8');
-    $training_date = htmlspecialchars($row['training_date'], ENT_QUOTES, 'UTF-8');
-    $training_logged = htmlspecialchars($row['training_logged'], ENT_QUOTES, 'UTF-8');
-    $lead_trainer = htmlspecialchars($row['lead_trainer'], ENT_QUOTES, 'UTF-8');
-    $training_type = htmlspecialchars($row['training_type'], ENT_QUOTES, 'UTF-8');
-    $training_country = htmlspecialchars($row['training_country'], ENT_QUOTES, 'UTF-8');
-    $training_location = htmlspecialchars($row['training_location'], ENT_QUOTES, 'UTF-8');
-    $registration_scope = htmlspecialchars($row['registration_scope'], ENT_QUOTES, 'UTF-8');
-    $location_full = htmlspecialchars($row['location_full'], ENT_QUOTES, 'UTF-8');
+    $training_title = htmlspecialchars($row['training_title'] ?? '', ENT_QUOTES, 'UTF-8');
+    $training_date = htmlspecialchars($row['training_date'] ?? '', ENT_QUOTES, 'UTF-8');
+    $training_logged = htmlspecialchars($row['training_logged'] ?? '', ENT_QUOTES, 'UTF-8');
+    $lead_trainer = htmlspecialchars($row['lead_trainer'] ?? '', ENT_QUOTES, 'UTF-8');
+    $training_type = htmlspecialchars($row['training_type'] ?? '', ENT_QUOTES, 'UTF-8');
+    $training_country = htmlspecialchars($row['training_country'] ?? '', ENT_QUOTES, 'UTF-8');
+    $training_location = htmlspecialchars($row['training_location'] ?? '', ENT_QUOTES, 'UTF-8');
+    $registration_scope = htmlspecialchars($row['registration_scope'] ?? '', ENT_QUOTES, 'UTF-8');
+    $location_full = isset($row['location_full']) ? htmlspecialchars($row['location_full'], ENT_QUOTES, 'UTF-8') : '';
 
-    $training_success = nl2br(htmlspecialchars($row['training_success'], ENT_QUOTES, 'UTF-8'));
-    $training_challenges = nl2br(htmlspecialchars($row['training_challenges'], ENT_QUOTES, 'UTF-8'));
-    $training_lessons_learned = nl2br(htmlspecialchars($row['training_lessons_learned'], ENT_QUOTES, 'UTF-8'));
-    $training_url = htmlspecialchars($row['training_url'], ENT_QUOTES, 'UTF-8');
+    $training_success = nl2br(htmlspecialchars($row['training_success'] ?? '', ENT_QUOTES, 'UTF-8'));
+    $training_challenges = nl2br(htmlspecialchars($row['training_challenges'] ?? '', ENT_QUOTES, 'UTF-8'));
+    $training_lessons_learned = nl2br(htmlspecialchars($row['training_lessons_learned'] ?? '', ENT_QUOTES, 'UTF-8'));
+    $training_url = htmlspecialchars($row['training_url'] ?? '', ENT_QUOTES, 'UTF-8');
     $ready_to_show = $row['ready_to_show'];
 
     // ✅ Fetch feature photos
-    $feature_photo1_main = htmlspecialchars($row['feature_photo1_main'], ENT_QUOTES, 'UTF-8');
-    $feature_photo2_main = htmlspecialchars($row['feature_photo2_main'], ENT_QUOTES, 'UTF-8');
-    $feature_photo1_tmb = htmlspecialchars($row['feature_photo1_tmb'], ENT_QUOTES, 'UTF-8');
+    $feature_photo1_main = htmlspecialchars($row['feature_photo1_main'] ?? '', ENT_QUOTES, 'UTF-8');
+    $feature_photo2_main = htmlspecialchars($row['feature_photo2_main'] ?? '', ENT_QUOTES, 'UTF-8');
+    $feature_photo3_main = htmlspecialchars($row['feature_photo3_main'] ?? '', ENT_QUOTES, 'UTF-8');
+    $feature_photo1_tmb = htmlspecialchars($row['feature_photo1_tmb'] ?? '', ENT_QUOTES, 'UTF-8');
 
     if ($ready_to_show == 0) {
         echo "<script>alert('Sorry this training isn\'t yet listed for public registration.'); window.location.href='trainings.php';</script>";
@@ -144,14 +145,14 @@ echo '<!DOCTYPE html>
                 <p style="font-size:1.1em;margin-top:10px;"><?php echo $training_type; ?></p>
                  <p style="font-size:1.3emm"><strong><?php echo $training_date; ?></strong></p>
 
-                <img src="../photos/events/terraces-forests-gladys.jpg" style="width:100%;border-radius: 10px;" id="event-lead-photo">
+                <img src="<?php echo $feature_photo1_main; ?>" style="width:100%;border-radius: 10px;" id="event-lead-photo">
 
                 <h2><?php echo $training_title; ?></h2>
                 <h4 >Lead by <?php echo $lead_trainer; ?></h4>
                <p><?php echo nl2br(htmlspecialchars_decode($training_summary)); ?></p>
 
 
-                <img src="../photos/events/r-a-tractatus.webp" style="width:100%;" id="event-lead-photo">
+                <img src="<?php echo $feature_photo2_main; ?>" style="width:100%;" id="event-lead-photo">
 
                 <p><?php echo $training_agenda; ?></p>
 
@@ -167,6 +168,9 @@ echo '<!DOCTYPE html>
 
 
 
+        <?php if (!empty($feature_photo3_main)): ?>
+            <img src="<?php echo $feature_photo3_main; ?>" style="width:100%;" id="event-lead-photo">
+        <?php endif; ?>
         <div id="event-details" class="dashboard-panel" style="margin-top:20px;font-size:small;">
             <h4>Community Event Details</h4>
             <hr>


### PR DESCRIPTION
## Summary
- avoid passing null to `htmlspecialchars` when loading training info
- fetch `feature_photo3_main`
- show feature photos in register page

## Testing
- `php -l en/register.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68427e548f648323b9d4c56adae5c500