### PR TITLE
Fix training trainers insertion

### DIFF
--- a/en/launch-training_process.php
+++ b/en/launch-training_process.php
@@ -201,10 +201,20 @@ if ($new_training_id && !empty($trainers)) {
     $del->close();
 
     $ins = $gobrik_conn->prepare("INSERT INTO tb_training_trainers (training_id, ecobricker_id) VALUES (?, ?)");
-    foreach ($trainers as $tr_id) {
-        $ins->bind_param("ii", $new_training_id, $tr_id);
-        $ins->execute();
+    if (!$ins) {
+        die("Prepare failed: " . $gobrik_conn->error);
     }
+
+    // avoid undefined variable notice that can corrupt JSON output
+    $tr_id = null;
+    $ins->bind_param("ii", $new_training_id, $tr_id);
+
+    foreach ($trainers as $tr_id) {
+        if (!$ins->execute()) {
+            error_log("Insert error for ecobricker $tr_id: " . $ins->error);
+        }
+    }
+
     $ins->close();
 }
 


### PR DESCRIPTION
## Summary
- fix INSERT handling for training trainers

## Testing
- `php -l en/launch-training_process.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_b_6842a7efaf8c83239ae0b77162874b6a