### PR TITLE
Fix trainer update when training_id missing

### DIFF
--- a/en/launch-training_process.php
+++ b/en/launch-training_process.php
@@ -18,6 +18,9 @@ if ($_SERVER["REQUEST_METHOD"] !== "POST") {
 }
 
 $training_id = isset($_POST['training_id']) ? intval($_POST['training_id']) : 0;
+if ($training_id <= 0 && isset($_GET['id'])) {
+    $training_id = intval($_GET['id']);
+}
 $editing = ($training_id > 0);
 
 $training_title = trim($_POST['training_title'] ?? '');


### PR DESCRIPTION
## Summary
- handle missing `training_id` when updating a training

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842b24cdd1083239eda488ff349b5c0