### PR TITLE
Remove lat/long fields from training pages

### DIFF
--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -71,7 +71,7 @@ $trainer_contact_email = '';
 // ✅ If editi   ng, fetch existing training details
 if ($editing) {
     $sql_fetch = "SELECT training_title, training_subtitle, lead_trainer, country_id, training_date, training_time_txt, no_participants,
-                  training_type, training_language, briks_made, avg_brik_weight, location_lat, location_long, training_location,
+                  training_type, training_language, briks_made, avg_brik_weight, training_location,
                   training_summary, training_agenda, training_success, training_challenges, training_lessons_learned,
                   youtube_result_video, moodle_url, ready_to_show, featured_description, community_id,
                   zoom_link, zoom_link_full, feature_photo1_main, feature_photo2_main, feature_photo3_main, registration_scope, trainer_contact_email
@@ -81,7 +81,7 @@ if ($editing) {
     $stmt_fetch->bind_param("i", $training_id);
     $stmt_fetch->execute();
     $stmt_fetch->bind_result($training_title, $training_subtitle, $lead_trainer, $country_id, $training_date, $training_time_txt, $no_participants,
-                            $training_type, $training_language, $briks_made, $avg_brik_weight, $latitude, $longitude, $training_location,
+                            $training_type, $training_language, $briks_made, $avg_brik_weight, $training_location,
                             $training_summary, $training_agenda, $training_success, $training_challenges,
                             $training_lessons_learned, $youtube_result_video, $moodle_url, $ready_to_show, $featured_description, $community_id,
                             $zoom_link, $zoom_link_full, $feature_photo1_main, $feature_photo2_main, $feature_photo3_main, $registration_scope, $trainer_contact_email);
@@ -975,13 +975,14 @@ function initFeatureImagePreviews() {
         const input = document.getElementById(id);
         if (input) {
             input.addEventListener('input', () => updateImagePreview(id, imgId, containerId));
+            input.addEventListener('change', () => updateImagePreview(id, imgId, containerId));
             updateImagePreview(id, imgId, containerId); // initial
         }
     });
 }
 
 if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initFeatureImagePreviews);
+    window.addEventListener('load', initFeatureImagePreviews);
 } else {
     initFeatureImagePreviews();
 }

--- a/en/launch-training_process.php
+++ b/en/launch-training_process.php
@@ -108,7 +108,7 @@ if ($editing) {
     $sql = "UPDATE tb_trainings SET
             training_title=?, training_subtitle=?, lead_trainer=?, country_id=?, training_date=?, training_time_txt=?,
             no_participants=?, training_type=?, training_language=?, briks_made=?, avg_brik_weight=?,
-            location_lat=?, location_long=?, training_location=?, training_summary=?, training_agenda=?,
+            training_location=?, training_summary=?, training_agenda=?,
             training_success=?, training_challenges=?, training_lessons_learned=?,
             youtube_result_video=?, moodle_url=?, ready_to_show=?, featured_description=?, community_id=?,
             zoom_link=?, zoom_link_full=?, registration_scope=?, trainer_contact_email=?
@@ -118,9 +118,9 @@ if ($editing) {
         echo json_encode(['success' => false, 'error' => 'Statement preparation failed.']);
         exit();
     }
-    $stmt->bind_param("sssississiiddssssssssisissssi",
+    $stmt->bind_param("sssississiissssssssisissssi",
         $training_title, $training_subtitle, $lead_trainer, $country_id, $training_date, $training_time_txt, $no_participants,
-        $training_type, $training_language, $briks_made, $avg_brik_weight, $latitude, $longitude, $training_location,
+        $training_type, $training_language, $briks_made, $avg_brik_weight, $training_location,
         $training_summary, $training_agenda, $training_success, $training_challenges,
         $training_lessons_learned, $youtube_result_video, $moodle_url, $ready_to_show,
         $featured_description, $community_id, $zoom_link, $zoom_link_full, $registration_scope, $trainer_contact_email,
@@ -157,8 +157,7 @@ if ($editing) {
 } else {
     $sql = "INSERT INTO tb_trainings
             (training_title, training_subtitle, lead_trainer, country_id, training_date, training_time_txt, no_participants,
-            training_type, training_language, briks_made, avg_brik_weight, location_lat, location_long,
-            training_location, training_summary, training_agenda, training_success, training_challenges,
+            training_type, training_language, briks_made, avg_brik_weight, training_location, training_summary, training_agenda, training_success, training_challenges,
             training_lessons_learned, youtube_result_video, moodle_url, ready_to_show, featured_description, community_id,
             zoom_link, zoom_link_full, registration_scope, trainer_contact_email)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
@@ -167,9 +166,9 @@ if ($editing) {
         echo json_encode(['success' => false, 'error' => 'Statement preparation failed.']);
         exit();
     }
-    $stmt->bind_param("sssississiiddssssssssisissss",
+    $stmt->bind_param("sssississiissssssssisissss",
         $training_title, $training_subtitle, $lead_trainer, $country_id, $training_date, $training_time_txt, $no_participants,
-        $training_type, $training_language, $briks_made, $avg_brik_weight, $latitude, $longitude, $training_location,
+        $training_type, $training_language, $briks_made, $avg_brik_weight, $training_location,
         $training_summary, $training_agenda, $training_success, $training_challenges,
         $training_lessons_learned, $youtube_result_video, $moodle_url, $ready_to_show, $featured_description, $community_id,
         $zoom_link, $zoom_link_full, $registration_scope, $trainer_contact_email


### PR DESCRIPTION
## Summary
- drop latitude and longitude handling from launch-training forms
- trigger feature image previews on window load and when image fields change

## Testing
- `php -l en/launch-training.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6842b8973e288323bc8f0fe278516aab