### PR TITLE
Fix trainer association update

### DIFF
--- a/en/launch-training_process.php
+++ b/en/launch-training_process.php
@@ -127,6 +127,10 @@ if ($editing) {
         $training_id
     );
     if ($stmt->execute()) {
+        if ($stmt->affected_rows === 0) {
+            echo json_encode(['success' => false, 'error' => 'Training not found.']);
+            exit();
+        }
         $new_training_id = $training_id;
     } else {
         echo json_encode(['success' => false, 'error' => 'Update failed.']);


### PR DESCRIPTION
## Summary
- ensure edited training exists before updating trainer associations

## Testing
- `php -l en/launch-training_process.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6842bf13d1f08323b8cf145e90b291ce