### PR TITLE
Add courses listing page

### DIFF
--- a/en/courses.php
+++ b/en/courses.php
@@ -1,0 +1,78 @@
+<?php
+require_once '../earthenAuth_helper.php';
+
+$lang = basename(dirname($_SERVER['SCRIPT_NAME']));
+$version = '0.01';
+$page = 'courses';
+$lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
+$is_logged_in = isLoggedIn();
+
+if ($is_logged_in) {
+    $buwana_id = $_SESSION['buwana_id'];
+    require_once '../gobrikconn_env.php';
+    require_once '../buwanaconn_env.php';
+    $user_continent_icon = getUserContinent($buwana_conn, $buwana_id);
+    $earthling_emoji = getUserEarthlingEmoji($buwana_conn, $buwana_id);
+    $user_location_watershed = getWatershedName($buwana_conn, $buwana_id);
+    $user_location_full = getUserFullLocation($buwana_conn, $buwana_id);
+    $gea_status = getGEA_status($buwana_id);
+    $user_community_name = getCommunityName($buwana_conn, $buwana_id);
+    $first_name = getFirstName($buwana_conn, $buwana_id);
+}
+
+require_once '../gobrikconn_env.php';
+
+$courses = [];
+$sql = "SELECT training_id, training_title, training_subtitle, lead_trainer, featured_description, training_type, training_location, training_language, training_date, training_time_txt, registration_scope, display_cost, feature_photo1_main FROM tb_trainings WHERE ready_to_show = 1 AND training_date >= CURDATE() ORDER BY training_date ASC";
+$result = $gobrik_conn->query($sql);
+if ($result) {
+    while ($row = $result->fetch_assoc()) {
+        $courses[] = $row;
+    }
+}
+$gobrik_conn->close();
+?>
+<!DOCTYPE html>
+<html lang="<?php echo htmlspecialchars($lang, ENT_QUOTES, 'UTF-8'); ?>">
+<head>
+<meta charset="UTF-8">
+<?php require_once("../includes/courses-inc.php"); ?>
+<div class="splash-title-block"></div>
+<div id="splash-bar"></div>
+<!-- PAGE CONTENT -->
+<div id="top-page-image" class="credentials-banner top-page-image"></div>
+<div id="form-submission-box" class="landing-page-form">
+    <div class="form-container">
+        <div style="text-align:center;width:100%;margin:auto;">
+            <h2 data-lang-id="001-current-courses">Current Courses</h2>
+            <p><span data-lang-id="002-course-selection">Select from our list of ongoing trainings, workshops and community events.</span></p>
+        </div>
+        <div class="course-grid">
+            <?php foreach ($courses as $course): ?>
+                <div class="course-module-box">
+                    <img src="<?php echo htmlspecialchars($course['feature_photo1_main']); ?>" alt="">
+                    <div class="course-module-info">
+                        <h3><?php echo htmlspecialchars($course['training_title']); ?></h3>
+                        <h4><?php echo htmlspecialchars($course['training_subtitle']); ?></h4>
+                        <div class="training-leaders"><?php echo htmlspecialchars($course['lead_trainer']); ?></div>
+                        <?php $desc = strip_tags($course['featured_description']); if(strlen($desc)>255) $desc = substr($desc,0,255).'...'; ?>
+                        <div class="course-description"><?php echo htmlspecialchars($desc); ?></div>
+                        <div class="module-caption-item">
+                            <?php echo htmlspecialchars($course['training_type']); ?> |
+                            <?php echo htmlspecialchars($course['training_location']); ?> |
+                            <?php echo htmlspecialchars($course['training_language']); ?> |
+                            <?php echo htmlspecialchars($course['training_date']); ?> |
+                            <?php echo htmlspecialchars($course['training_time_txt']); ?> |
+                            <?php echo htmlspecialchars($course['registration_scope']); ?>
+                            <?php if (!empty($course['display_cost'])) { echo ' | ' . htmlspecialchars($course['display_cost']); } ?>
+                        </div>
+                    </div>
+                    <a class="learn-more-btn" href="register.php?id=<?php echo $course['training_id']; ?>">Learn More</a>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+</div>
+</body>
+</html>
+

--- a/includes/courses-inc.php
+++ b/includes/courses-inc.php
@@ -1,0 +1,118 @@
+<!--  Set any page specific graphics to preload-->
+
+<?php require_once ("../meta/$page-$lang.php");?>
+
+<STYLE>
+
+.course-grid {
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:center;
+  gap:20px;
+}
+
+.course-module-box {
+  background: var(--darker);
+  border-radius: 12px;
+  overflow: hidden;
+  display:flex;
+  flex-direction: column;
+  transition: transform 0.2s, box-shadow 0.2s;
+  width:100%;
+  max-width:300px;
+}
+
+.course-module-box:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+}
+
+.course-module-box img {
+  width:100%;
+  display:block;
+}
+
+.course-module-info {
+  padding:15px;
+  text-align:left;
+}
+
+.course-module-info h3 {
+  font-family: 'Arvo', serif;
+  font-size:1.5em;
+  color: var(--h1);
+  margin:0 0 5px 0;
+}
+
+.course-module-info h4 {
+  font-family: 'Mulish', sans-serif;
+  font-size:1.3em;
+  color: var(--text-color);
+  margin:0 0 8px 0;
+}
+
+.training-leaders {
+  font-family:'Mulish', sans-serif;
+  font-size:1.2em;
+  font-weight:400;
+  color: var(--text-color);
+  margin-bottom:8px;
+}
+
+.course-description {
+  font-family:'Mulish', sans-serif;
+  font-size:1em;
+  color: var(--text-color);
+  margin-bottom:8px;
+}
+
+.module-caption-item {
+  font-family:'Mulish', sans-serif;
+  font-size:0.9em;
+  color: var(--subdued-text);
+}
+
+.learn-more-btn {
+  background: limegreen;
+  color:white;
+  text-align:center;
+  padding:8px 12px;
+  margin:10px;
+  border-radius:6px;
+  text-decoration:none;
+  display:block;
+  transition: background-color 0.2s;
+}
+
+.course-module-box:hover .learn-more-btn {
+  background: green;
+}
+
+@media (min-width:1000px) {
+  .course-module-box { flex-basis: calc(33.33% - 20px); }
+}
+@media (min-width:769px) and (max-width:999px) {
+  .course-module-box { flex-basis: calc(50% - 20px); }
+}
+@media (max-width:768px) {
+  .course-module-box { flex-basis: 100%; }
+}
+
+#main {
+  height:fit-content;
+}
+
+#splash-bar {
+  background-color: var(--top-header);
+  filter:none!important;
+  margin-bottom:-200px!important;
+}
+
+.form-container {
+  max-width:800px!important;
+  box-shadow:#0000001f 0px 5px 20px;
+}
+
+</style>
+
+<?php require_once ("../header-2024.php");?>

--- a/meta/courses-en.php
+++ b/meta/courses-en.php
@@ -1,0 +1,17 @@
+<!-- Meta tags for page display and search engine listing-->
+<title>Current Courses</title>
+<meta name="description" content="Select from our list of ongoing trainings, workshops and community events on regenerative topics">
+<meta name="keywords" content="courses, trainings, workshops, community events">
+<meta name="author" content="GoBrik.com">
+<meta name="last-modified" content="' . $lastModified . '">
+<meta name="revised" content="' . $lastModified . '">
+<!-- Facebook Open Graph Tags for social sharing-->
+<meta property="og:url" content="https://gobrik.com/' . $lang . '/' . $page . '">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Current Courses">
+<meta property="og:description" content="Select from our list of ongoing trainings, workshops and community events on regenerative topics">
+<meta property="og:image" content="https://gobrik.com/images/social-banner-1200px.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="1000">
+<meta property="og:image:alt" content="Courses banner">
+<meta property="og:locale" content="' . $lang . '_GB">

--- a/meta/courses-es.php
+++ b/meta/courses-es.php
@@ -1,0 +1,17 @@
+<!-- Etiquetas meta para la visualización de la página y la lista de motores de búsqueda -->
+<title>Cursos Actuales</title>
+<meta name="description" content="Seleccione de nuestra lista de formaciones, talleres y eventos comunitarios en temas regenerativos">
+<meta name="keywords" content="cursos, formaciones, talleres, eventos comunitarios">
+<meta name="author" content="GoBrik.com">
+<meta name="last-modified" content="' . $lastModified . '">
+<meta name="revised" content="' . $lastModified . '">
+<!-- Etiquetas Open Graph de Facebook para compartir en redes sociales -->
+<meta property="og:url" content="https://gobrik.com/' . $lang . '/' . $page . '">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Cursos Actuales">
+<meta property="og:description" content="Seleccione de nuestra lista de formaciones, talleres y eventos comunitarios en temas regenerativos">
+<meta property="og:image" content="https://gobrik.com/images/social-banner-1200px.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="1000">
+<meta property="og:image:alt" content="Banner de cursos">
+<meta property="og:locale" content="es_ES">

--- a/meta/courses-fr.php
+++ b/meta/courses-fr.php
@@ -1,0 +1,17 @@
+<!-- Balises méta pour l'affichage de la page et le référencement -->
+<title>Cours Actuels</title>
+<meta name="description" content="Sélectionnez parmi notre liste de formations, d'ateliers et d'événements communautaires sur des sujets régénératifs">
+<meta name="keywords" content="cours, formations, ateliers, événements communautaires">
+<meta name="author" content="GoBrik.com">
+<meta name="last-modified" content="' . $lastModified . '">
+<meta name="revised" content="' . $lastModified . '">
+<!-- Balises Open Graph de Facebook pour le partage social -->
+<meta property="og:url" content="https://gobrik.com/' . $lang . '/' . $page . '">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Cours Actuels">
+<meta property="og:description" content="Sélectionnez parmi notre liste de formations, d'ateliers et d'événements communautaires sur des sujets régénératifs">
+<meta property="og:image" content="https://gobrik.com/images/social-banner-1200px.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="1000">
+<meta property="og:image:alt" content="Bannière des cours">
+<meta property="og:locale" content="fr_FR">

--- a/meta/courses-id.php
+++ b/meta/courses-id.php
@@ -1,0 +1,17 @@
+<!-- Tag meta untuk tampilan halaman dan pencarian -->
+<title>Kursus Saat Ini</title>
+<meta name="description" content="Pilih dari daftar pelatihan, lokakarya, dan acara komunitas kami yang sedang berlangsung tentang topik regeneratif">
+<meta name="keywords" content="kursus, pelatihan, lokakarya, acara komunitas">
+<meta name="author" content="GoBrik.com">
+<meta name="last-modified" content="' . $lastModified . '">
+<meta name="revised" content="' . $lastModified . '">
+<!-- Tag Open Graph Facebook untuk berbagi sosial -->
+<meta property="og:url" content="https://gobrik.com/' . $lang . '/' . $page . '">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Kursus Saat Ini">
+<meta property="og:description" content="Pilih dari daftar pelatihan, lokakarya, dan acara komunitas kami yang sedang berlangsung tentang topik regeneratif">
+<meta property="og:image" content="https://gobrik.com/images/social-banner-1200px.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="1000">
+<meta property="og:image:alt" content="Banner kursus">
+<meta property="og:locale" content="id_ID">

--- a/translations/courses-en.js
+++ b/translations/courses-en.js
@@ -1,0 +1,8 @@
+/*-----------------------------------
+TEXT TRANSLATION SNIPPETS FOR GOBRIK.com
+-----------------------------------*/
+
+const en_Page_Translations = {
+    "001-current-courses": "Current Courses",
+    "002-course-selection": "Select from our list of ongoing trainings, workshops and community events."
+};

--- a/translations/courses-es.js
+++ b/translations/courses-es.js
@@ -1,0 +1,8 @@
+/*-----------------------------------
+TEXT TRANSLATION SNIPPETS FOR GOBRIK.com
+-----------------------------------*/
+
+const es_Page_Translations = {
+    "001-current-courses": "Cursos Actuales",
+    "002-course-selection": "Seleccione de nuestra lista de formaciones, talleres y eventos comunitarios en curso."
+};

--- a/translations/courses-fr.js
+++ b/translations/courses-fr.js
@@ -1,0 +1,8 @@
+/*-----------------------------------
+TEXT TRANSLATION SNIPPETS FOR GOBRIK.com
+-----------------------------------*/
+
+const fr_Page_Translations = {
+    "001-current-courses": "Cours Actuels",
+    "002-course-selection": "Sélectionnez parmi notre liste de formations, d'ateliers et d'événements communautaires en cours."
+};

--- a/translations/courses-id.js
+++ b/translations/courses-id.js
@@ -1,0 +1,8 @@
+/*-----------------------------------
+TEXT TRANSLATION SNIPPETS FOR GOBRIK.com
+-----------------------------------*/
+
+const id_Page_Translations = {
+    "001-current-courses": "Kursus Saat Ini",
+    "002-course-selection": "Pilih dari daftar pelatihan, lokakarya, dan acara komunitas yang sedang berlangsung."
+};


### PR DESCRIPTION
## Summary
- create `courses.php` page listing upcoming trainings
- add custom css in `includes/courses-inc.php`
- provide page translations for en, es, fr and id
- add meta descriptions for the page in four languages

## Testing
- `php -l en/courses.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6843d414cb208323b756ad703bcdc241