### PR TITLE
Fix trainer tag removal and image layout

### DIFF
--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -434,10 +434,10 @@ if (!empty($community_id)) {
 
     <!-- ======================= Feature Photo 1 ======================= -->
     <div class="form-item">
-        <label for="feature_photo1_main">Set Feature Photo</label><br>
 <?php if ($editing && !empty($feature_photo1_main)): ?>
     <img src="<?php echo htmlspecialchars($feature_photo1_main, ENT_QUOTES, 'UTF-8'); ?>" style="max-width:300px;max-height:180px;margin-bottom:5px;" alt="Feature Photo 1">
 <?php endif; ?>
+        <label for="feature_photo1_main">Set Feature Photo</label><br>
 
         <input type="url" id="feature_photo1_main" name="feature_photo1_main" class="form-field-style" value="<?php echo htmlspecialchars($feature_photo1_main ?? '', ENT_QUOTES, 'UTF-8'); ?>">
         <p class="form-caption">
@@ -447,10 +447,10 @@ if (!empty($community_id)) {
 
     <!-- ======================= Feature Photo 2 ======================= -->
     <div class="form-item">
-        <label for="feature_photo2_main">Set a Second Training Feature Photo</label><br>
 <?php if ($editing && !empty($feature_photo2_main)): ?>
     <img src="<?php echo htmlspecialchars($feature_photo2_main, ENT_QUOTES, 'UTF-8'); ?>" style="max-width:300px;max-height:180px;margin-bottom:5px;" alt="Feature Photo 2">
 <?php endif; ?>
+        <label for="feature_photo2_main">Set a Second Training Feature Photo</label><br>
 
         <input type="url" id="feature_photo2_main" name="feature_photo2_main" class="form-field-style" value="<?php echo htmlspecialchars($feature_photo2_main ?? '', ENT_QUOTES, 'UTF-8'); ?>">
         <p class="form-caption">
@@ -460,11 +460,10 @@ if (!empty($community_id)) {
 
     <!-- ======================= Feature Photo 3 ======================= -->
     <div class="form-item">
-        <label for="feature_photo3_main">Set a Third Training Feature Photo</label><br>
-
 <?php if ($editing && !empty($feature_photo3_main)): ?>
     <img src="<?php echo htmlspecialchars($feature_photo3_main, ENT_QUOTES, 'UTF-8'); ?>" style="max-width:300px;max-height:180px;margin-bottom:5px;" alt="Feature Photo 3">
 <?php endif; ?>
+        <label for="feature_photo3_main">Set a Third Training Feature Photo</label><br>
         <input type="url" id="feature_photo3_main" name="feature_photo3_main" class="form-field-style" value="<?php echo htmlspecialchars($feature_photo3_main ?? '', ENT_QUOTES, 'UTF-8'); ?>">
         <p class="form-caption">
             This image will also be visible on the training registration page.
@@ -649,6 +648,16 @@ document.addEventListener("DOMContentLoaded", function() {
         box.appendChild(hidden);
         trainerContainer.appendChild(box);
     }
+
+    // Attach remove functionality to any pre-rendered trainer tags
+    document.querySelectorAll('#selected_trainers .trainer-tag-box').forEach(function(box) {
+        var removeBtn = box.querySelector('.remove-trainer');
+        if (removeBtn) {
+            removeBtn.addEventListener('click', function() {
+                box.remove();
+            });
+        }
+    });
 
     trainerInput.addEventListener('input', function() {
         fetchTrainers(trainerInput.value.trim());

--- a/styles/main.css
+++ b/styles/main.css
@@ -2316,7 +2316,7 @@ input[type="text"], input[type="name"], input[type="credential"],  input[type="p
   border: 3px solid var(--button-2-1);
   border-radius: 5px;
   background-color: var(--top-header);
-  color: var(--h1);
+  color: var(--text-color);
    border: 1.5px solid var(--button-2-1);
 }
 
@@ -2333,7 +2333,7 @@ select {
   border-radius: 5px;
   background-color: var(--top-header);
    border: 2px solid var(--button-2-1);
-   color: var(--h1);
+   color: var(--text-color);
 }
 
 select option:disabled {


### PR DESCRIPTION
## Summary
- allow removing pre-populated trainers
- reposition featured image labels below previews
- ensure text color for form inputs uses `--text-color`

## Testing
- `php -l en/launch-training.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684411b72bec83238a71b80567072ce6