### PR TITLE
Adjust register page buttons and unregistration

### DIFF
--- a/includes/register-inc.php
+++ b/includes/register-inc.php
@@ -17,34 +17,31 @@
 <STYLE>
 
 
-#rsvp-register-button  {
-
+#rsvp-register-button-desktop,
+#rsvp-register-button-mobile  {
     color: white;
-   padding: 10px 20px;
-   border: none;
-   border-radius: 5px;
-   cursor: pointer;
-   background: var(--emblem-green);
-   font-size: 1.3em;
-   justify-content: center;
-   text-align: center;
-   text-decoration: none;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    background: var(--emblem-green);
+    font-size: 1.3em;
+    justify-content: center;
+    text-align: center;
+    text-decoration: none;
     margin-top: 10px;
     display: flex;
-
-    }
+    width: 80%;
+}
 
 @media screen and (max-width: 768px) {
-    #rsvp-register-button {
-        width: 100%;
-    }
+    #rsvp-register-button-desktop { display:none; }
+    #rsvp-register-button-mobile { display:flex; }
 }
 
 @media screen and (min-width: 769px) {
-    #rsvp-register-button {
-        width: auto;
-        align-self: flex-start;
-    }
+    #rsvp-register-button-mobile { display:none; }
+    #rsvp-register-button-desktop { display:flex; align-self:flex-start; }
 }
 
 


### PR DESCRIPTION
## Summary
- handle ampersands when loading training data
- style mobile and desktop RSVP buttons separately
- add responsive behaviour in register page JS
- show a confirmation modal after successful un-registration

## Testing
- `php -l en/register.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68443d6c1eec8323a7193530610f4721