### PR TITLE
Fix registration modal and make notices closable

### DIFF
--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -169,7 +169,9 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
 
 <div id="slider-box">
     <div id="registered-notice" class="top-container-notice">
-                <span style="margin-right:10px;">👍</span><span> GoBrik now has a slider to show the latest awesome ecobricks logged by ecobrickers like you around the world.</span>
+                <span style="margin-right:10px;">👍</span>
+                <span> GoBrik now has a slider to show the latest awesome ecobricks logged by ecobrickers like you around the world.</span>
+                <button class="notice-close" aria-label="Close">&times;</button>
             </div>
     <div id="ecobrick-slider">
         <?php foreach ($featured_ecobricks as $index => $brick): ?>

--- a/en/register.php
+++ b/en/register.php
@@ -184,7 +184,9 @@ echo '<!DOCTYPE html>
 
                 <?php if ($is_registered): ?>
         <div id="registered-notice" class="top-container-notice">
-            <span style="margin-right:10px;">👍</span><span> You're registered for this <?php echo $training_type; ?>!  See your email or <a href="dashboard.php">dashboard</a> for full registration details.</span>
+            <span style="margin-right:10px;">👍</span>
+            <span> You're registered for this <?php echo $training_type; ?>!  See your email or <a href="dashboard.php">dashboard</a> for full registration details.</span>
+            <button class="notice-close" aria-label="Close">&times;</button>
         </div>
     <?php endif; ?>
 
@@ -306,7 +308,8 @@ function handleRegistrationClick() {
                 <?php echo json_encode($training_time_txt); ?>,
                 <?php echo json_encode($training_location); ?>,
                 <?php echo json_encode($display_cost); ?>,
-                <?php echo json_encode($users_email_address); ?>
+                <?php echo json_encode($users_email_address); ?>,
+                <?php echo json_encode($first_name); ?>
             );
         <?php endif; ?>
     <?php else: ?>
@@ -330,7 +333,7 @@ function openInfoModal() {
             <h2>Login to Register</h2>
             <p>To register for this course you must use your GoBrik account.</p>
             <div style="text-align:center;width:100%;margin:auto;margin-top:10px;margin-bottom:10px;">
-                <a href="login.php?redirect=register.php?id=<?php echo $training_id; ?>" class="confirm-button enabled" style="width:77%;">Login</a>
+                <a href="login.php?redirect=register.php?id=<?php echo $training_id; ?>?status=relanding" class="confirm-button enabled" style="width:77%;">Login</a>
                 <a href="signup.php" class="confirm-button enabled" style="width:77%;">Sign Up</a>
             </div>
             <p style="font-size: 1em; color: grey;">GoBrik authentication is powered by Buwana SSO for regenerative apps</p>
@@ -349,7 +352,7 @@ function closeInfoModal() {
     document.body.classList.remove('modal-open');
 }
 
-function openConfirmRegistrationModal(trainingName, trainingType, trainingDate, trainingTime, trainingLocation, displayCost, userEmail) {
+function openConfirmRegistrationModal(trainingName, trainingType, trainingDate, trainingTime, trainingLocation, displayCost, userEmail, firstName) {
     const modal = document.getElementById('form-modal-message');
     const messageContainer = modal.querySelector('.modal-message');
     const photobox = document.getElementById('modal-photo-box');
@@ -361,7 +364,7 @@ function openConfirmRegistrationModal(trainingName, trainingType, trainingDate, 
             <div>
                 <h1>✔️</h1>
                 <h2>${trainingName}</h2>
-                <p>${first_name}, please confirm your registration to this ${trainingType} taking place at ${trainingDate} (${trainingTime}) on ${trainingLocation}. The training is ${displayCost} so there is no need to make any initial payments.</p>
+                <p>${firstName}, please confirm your registration to this ${trainingType} taking place at ${trainingDate} (${trainingTime}) on ${trainingLocation}. The training is ${displayCost} so there is no need to make any initial payments.</p>
             </div>
             <div style="display:flex;width:100%;margin-top:20px;flex-flow:column">
                 <a href="registration_confirmation.php?id=<?php echo $training_id; ?>&ecobricker_id=<?php echo $ecobricker_id; ?>" class="confirm-button enabled" style="flex:1;width:80%;">Confirm Registration</a>
@@ -460,8 +463,26 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 });
+
 <?php endif; ?>
 </script>
+
+<?php if (isset($_GET['status']) && $_GET['status'] == 'relanding'): ?>
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+    openConfirmRegistrationModal(
+        <?php echo json_encode($training_name); ?>,
+        <?php echo json_encode($training_type); ?>,
+        <?php echo json_encode($training_date); ?>,
+        <?php echo json_encode($training_time_txt); ?>,
+        <?php echo json_encode($training_location); ?>,
+        <?php echo json_encode($display_cost); ?>,
+        <?php echo json_encode($users_email_address); ?>,
+        <?php echo json_encode($first_name); ?>
+    );
+});
+</script>
+<?php endif; ?>
 
 <?php if (isset($_GET['registered']) && $_GET['registered'] == 1): ?>
 <script>
@@ -485,7 +506,7 @@ function openRegistrationSuccessModal(trainingTitle) {
             <h4>See you at <i>${trainingTitle}</i></h4>
             <p>Check your email for your registration confirmation and Zoom invitation link.</p>
             <div style="text-align:center;width:100%;margin:auto;margin-top:10px;margin-bottom:10px;">
-                <a href="register.php" class="confirm-button enabled" style="margin-top: 20px; font-size: 1.2em; padding: 10px 20px; cursor: pointer;">Got it!</a>
+                <a href="register.php?id=<?php echo $training_id; ?>" class="confirm-button enabled" style="margin-top: 20px; font-size: 1.2em; padding: 10px 20px; cursor: pointer;">Got it!</a>
             </div>
         </div>
     `;

--- a/scripts/core-2024.js
+++ b/scripts/core-2024.js
@@ -593,3 +593,15 @@ function handleLogout(event) {
         element.classList.add('shake');
         setTimeout(() => element.classList.remove('shake'), 400);
     }
+
+// Close notices when X is clicked
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.notice-close').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            const notice = this.closest('.top-container-notice');
+            if (notice) {
+                notice.style.display = 'none';
+            }
+        });
+    });
+});

--- a/styles/main.css
+++ b/styles/main.css
@@ -2241,6 +2241,16 @@ font-family: 'Mulish', sans-serif;
   z-index: 30;
 }
 
+.notice-close {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.2em;
+  cursor: pointer;
+  padding-left: 8px;
+}
+
 @media screen and (min-width: 770px) {
     .top-container-notice {
         width: 60%;


### PR DESCRIPTION
## Summary
- show close button on "registered" notice and dashboard notice
- greet user by first name in confirm modal
- auto open confirm modal when `status=relanding`
- adjust login link and success modal
- add global JS handler and notice CSS

## Testing
- `php -l en/register.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68446331a29c8323ad3a23f1f99e7090