### PR TITLE
Handle relanding URL for registration

### DIFF
--- a/en/register.php
+++ b/en/register.php
@@ -467,7 +467,16 @@ document.addEventListener('DOMContentLoaded', function() {
 <?php endif; ?>
 </script>
 
-<?php if (isset($_GET['status']) && $_GET['status'] == 'relanding'): ?>
+<?php
+$relanding = false;
+if (isset($_GET['status']) && $_GET['status'] == 'relanding') {
+    $relanding = true;
+} elseif (isset($_GET['id']) && strpos($_GET['id'], 'status=relanding') !== false) {
+    $relanding = true;
+} elseif (strpos($_SERVER['REQUEST_URI'], 'status=relanding') !== false) {
+    $relanding = true;
+}
+if ($relanding): ?>
 <script>
 document.addEventListener("DOMContentLoaded", function() {
     openConfirmRegistrationModal(


### PR DESCRIPTION
## Summary
- open confirmation modal automatically for malformed `status=relanding` URLs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6844686d16388323b13d73fd26b29c77