### PR TITLE
Fix null checks for training confirmation email

### DIFF
--- a/en/registration_confirmation.php
+++ b/en/registration_confirmation.php
@@ -38,7 +38,16 @@ $stmt_training->bind_result($training_title, $training_date, $zoom_link, $traini
 $stmt_training->fetch();
 $stmt_training->close();
 
-if (!isset($zoom_link_full)) {
+// Ensure optional fields are strings to satisfy strict typing
+// Use empty strings for potentially null database values
+$feature_photo1_tmb     = $feature_photo1_tmb     ?? '';
+$agenda_url             = $agenda_url             ?? '';
+$lead_trainer           = $lead_trainer           ?? '';
+$trainer_contact_email  = $trainer_contact_email  ?? '';
+$zoom_link_full         = $zoom_link_full         ?? '';
+$zoom_link              = $zoom_link              ?? '';
+
+if (empty($zoom_link_full)) {
     $zoom_link_full = "No additional Zoom details available.";
 }
 


### PR DESCRIPTION
## Summary
- handle null DB values in registration confirmation

## Testing
- `php -l en/registration_confirmation.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68451a83d7248323bb6bfd7871a74762