### PR TITLE
Format training date in meta descriptions

### DIFF
--- a/meta/register-en.php
+++ b/meta/register-en.php
@@ -1,12 +1,12 @@
 <title><?php echo $training_title; ?></title>
 <meta name="keywords" content="GEA Registration, Community, Event, Webinar, Course">
-<meta name="description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
+<meta name="description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo date('F j, Y', strtotime($training_date)); ?>">
 
 <!-- Facebook Open Graph Tags for social sharing -->
 <meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/register.php?id=<?php echo $training_id; ?>">
 <meta property="og:type" content="website">
 <meta property="og:title" content="<?php echo $training_title; ?>">
-<meta property="og:description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo $training_date; ?>">
+<meta property="og:description" content="Register for our <?php echo $training_type; ?> led by <?php echo $lead_trainer; ?> on <?php echo date('F j, Y', strtotime($training_date)); ?>">
 <?php $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : 'https://www.gobrik.com/photos/events/terraces-forests-gladys.jpg'; ?>
 <meta property="og:image" content="<?php echo $og_image; ?>">
 <meta property="fb:app_id" content="1781710898523821">

--- a/meta/register-es.php
+++ b/meta/register-es.php
@@ -1,12 +1,12 @@
 <title><?php echo $training_title; ?></title>
 <meta name="keywords" content="Registro GEA, Evento comunitario, Webinar, Curso">
-<meta name="description" content="Regístrese para nuestro <?php echo $training_type; ?> dirigido por <?php echo $lead_trainer; ?> el <?php echo $training_date; ?>">
+<meta name="description" content="Regístrese para nuestro <?php echo $training_type; ?> dirigido por <?php echo $lead_trainer; ?> el <?php echo date('F j, Y', strtotime($training_date)); ?>">
 
 <!-- Facebook Open Graph Tags for social sharing -->
 <meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/register.php?id=<?php echo $training_id; ?>">
 <meta property="og:type" content="website">
 <meta property="og:title" content="<?php echo $training_title; ?>">
-<meta property="og:description" content="Regístrese para nuestro <?php echo $training_type; ?> dirigido por <?php echo $lead_trainer; ?> el <?php echo $training_date; ?>">
+<meta property="og:description" content="Regístrese para nuestro <?php echo $training_type; ?> dirigido por <?php echo $lead_trainer; ?> el <?php echo date('F j, Y', strtotime($training_date)); ?>">
 <?php $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : 'https://www.gobrik.com/photos/events/terraces-forests-gladys.jpg'; ?>
 <meta property="og:image" content="<?php echo $og_image; ?>">
 <meta property="fb:app_id" content="1781710898523821">

--- a/meta/register-fr.php
+++ b/meta/register-fr.php
@@ -1,12 +1,12 @@
 <title><?php echo $training_title; ?></title>
 <meta name="keywords" content="Inscription GEA, Événement communautaire, Webinaire, Cours">
-<meta name="description" content="Inscrivez-vous à notre <?php echo $training_type; ?> animé par <?php echo $lead_trainer; ?> le <?php echo $training_date; ?>">
+<meta name="description" content="Inscrivez-vous à notre <?php echo $training_type; ?> animé par <?php echo $lead_trainer; ?> le <?php echo date('F j, Y', strtotime($training_date)); ?>">
 
 <!-- Facebook Open Graph Tags for social sharing -->
 <meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/register.php?id=<?php echo $training_id; ?>">
 <meta property="og:type" content="website">
 <meta property="og:title" content="<?php echo $training_title; ?>">
-<meta property="og:description" content="Inscrivez-vous à notre <?php echo $training_type; ?> animé par <?php echo $lead_trainer; ?> le <?php echo $training_date; ?>">
+<meta property="og:description" content="Inscrivez-vous à notre <?php echo $training_type; ?> animé par <?php echo $lead_trainer; ?> le <?php echo date('F j, Y', strtotime($training_date)); ?>">
 <?php $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : 'https://www.gobrik.com/photos/events/terraces-forests-gladys.jpg'; ?>
 <meta property="og:image" content="<?php echo $og_image; ?>">
 <meta property="fb:app_id" content="1781710898523821">

--- a/meta/register-id.php
+++ b/meta/register-id.php
@@ -1,12 +1,12 @@
 <title><?php echo $training_title; ?></title>
 <meta name="keywords" content="Pendaftaran GEA, Acara komunitas, Webinar, Kursus">
-<meta name="description" content="Daftar untuk <?php echo $training_type; ?> yang dipimpin oleh <?php echo $lead_trainer; ?> pada <?php echo $training_date; ?>">
+<meta name="description" content="Daftar untuk <?php echo $training_type; ?> yang dipimpin oleh <?php echo $lead_trainer; ?> pada <?php echo date('F j, Y', strtotime($training_date)); ?>">
 
 <!-- Facebook Open Graph Tags for social sharing -->
 <meta property="og:url" content="https://www.gobrik.com/<?php echo $lang; ?>/register.php?id=<?php echo $training_id; ?>">
 <meta property="og:type" content="website">
 <meta property="og:title" content="<?php echo $training_title; ?>">
-<meta property="og:description" content="Daftar untuk <?php echo $training_type; ?> yang dipimpin oleh <?php echo $lead_trainer; ?> pada <?php echo $training_date; ?>">
+<meta property="og:description" content="Daftar untuk <?php echo $training_type; ?> yang dipimpin oleh <?php echo $lead_trainer; ?> pada <?php echo date('F j, Y', strtotime($training_date)); ?>">
 <?php $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : 'https://www.gobrik.com/photos/events/terraces-forests-gladys.jpg'; ?>
 <meta property="og:image" content="<?php echo $og_image; ?>">
 <meta property="fb:app_id" content="1781710898523821">


### PR DESCRIPTION
## Summary
- format `training_date` in meta register pages so the time is omitted

## Testing
- `php -l meta/register-en.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845215bf6dc83238b4b3a659c0bad1e