### PR TITLE
Add admin alert reset to newsletter tool

### DIFF
--- a/en/earthen-sender.php
+++ b/en/earthen-sender.php
@@ -198,6 +198,7 @@ echo '<!DOCTYPE html>
                 <?php endforeach; ?>
             </ul>
             <p>Please resolve these alerts before proceeding.</p>
+            <button id="reset-alerts-button" class="confirm-button delete" style="margin-top:10px;">✅ Alerts Resolved</button>
         </div>
     <?php endif; ?>
 
@@ -444,6 +445,30 @@ $(document).ready(function () {
         if (autoSendEnabled() && recipientEmail) {
             sendEmail();
         }
+    });
+
+    // 🔹 Reset admin alerts
+    $('#reset-alerts-button').on('click', function (e) {
+        e.preventDefault();
+        if (!confirm('Mark all admin alerts as addressed?')) {
+            return;
+        }
+        $.ajax({
+            url: '../scripts/reset_admin_alerts.php',
+            type: 'POST',
+            dataType: 'json',
+            success: function (resp) {
+                if (resp.success) {
+                    alert('✅ Alerts have been reset.');
+                    location.reload();
+                } else {
+                    alert('❌ Failed to reset alerts.');
+                }
+            },
+            error: function () {
+                alert('❌ Failed to reset alerts.');
+            }
+        });
     });
 
     // 🔹 Initial state from localStorage

--- a/scripts/reset_admin_alerts.php
+++ b/scripts/reset_admin_alerts.php
@@ -1,0 +1,19 @@
+<?php
+require_once '../buwanaconn_env.php';
+header('Content-Type: application/json');
+
+$response = ['success' => false];
+
+try {
+    $sql = "UPDATE admin_alerts SET addressed = 1 WHERE addressed = 0";
+    if ($buwana_conn->query($sql) === TRUE) {
+        $response['success'] = true;
+    } else {
+        $response['error'] = $buwana_conn->error;
+    }
+} catch (Exception $e) {
+    $response['error'] = $e->getMessage();
+}
+
+echo json_encode($response);
+


### PR DESCRIPTION
## Summary
- add ability to clear admin alerts when using the newsletter sender
- create `reset_admin_alerts.php` script for resetting alerts

## Testing
- `php -l en/earthen-sender.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_b_684bc5e7abf083238e964f0351d3c30d