### PR TITLE
Improve sender auto send clarity

### DIFF
--- a/emailing/webhook_handler.php
+++ b/emailing/webhook_handler.php
@@ -113,34 +113,52 @@ if (stripos($response_message, "rate limited") !== false || stripos($response_me
         error_log("❌ No record found for $email_addr in tb_ecobrickers!");
     }
 
-    // 🚨 Update the database with the new emailing status 🚨
-    $sql_update_status = "
-        UPDATE tb_ecobrickers
-        SET emailing_status = ?
-        WHERE email_addr = ?
-    ";
+    // 🚨 Prioritize status updates to avoid downgrades 🚨
+    $priority = [
+        'failed' => 3,
+        'bounced' => 3,
+        'complained' => 3,
+        'delivered' => 2,
+        'accepted' => 1
+    ];
 
-    $stmt_update_status = $gobrik_conn->prepare($sql_update_status);
-    if (!$stmt_update_status) {
-        throw new Exception('❌ Error preparing update statement: ' . $gobrik_conn->error);
+    $current_level = $priority[strtolower($current_status)] ?? 0;
+    $new_level = $priority[strtolower($basic_mailgun_status)] ?? 0;
+
+    if ($new_level >= $current_level) {
+        $sql_update_status = "UPDATE tb_ecobrickers SET emailing_status = ? WHERE email_addr = ?";
+        $stmt_update_status = $gobrik_conn->prepare($sql_update_status);
+        if (!$stmt_update_status) {
+            throw new Exception('❌ Error preparing update statement: ' . $gobrik_conn->error);
+        }
+        $stmt_update_status->bind_param('ss', $basic_mailgun_status, $email_addr);
+        $stmt_update_status->execute();
+
+        if ($stmt_update_status->affected_rows > 0) {
+            error_log("✅ Delivered! Emailing_status set to '$basic_mailgun_status' for $email_addr.");
+        } else {
+            error_log("👌️ No update needed for $email_addr. Emailing_status was already '$basic_mailgun_status'.");
+        }
+
+        $stmt_update_status->close();
+    } else {
+        error_log("👌️ Ignored lower priority status '$basic_mailgun_status' for $email_addr.");
     }
 
-    // Bind parameters and execute the statement
-    $stmt_update_status->bind_param('ss', $basic_mailgun_status, $email_addr);
-    $stmt_update_status->execute();
-
-    // 🚨 Check if any row was actually updated 🚨
-    if ($stmt_update_status->affected_rows > 0) {
-        error_log("✅ Delivered! Emailing_status set to '$basic_mailgun_status' for $email_addr.");
-    } else {
-        if ($current_status === $basic_mailgun_status) {
-            error_log("👌️ No update needed for $email_addr. Emailing_status was already '$basic_mailgun_status'.");
+    // If Mailgun confirms delivery, mark the newsletter member as sent
+    if ($basic_mailgun_status === 'delivered') {
+        $stmt_update_member = $buwana_conn->prepare(
+            "UPDATE earthen_members_tb SET test_sent = 1, test_sent_date_time = NOW() WHERE email = ? AND test_sent = 0"
+        );
+        if ($stmt_update_member) {
+            $stmt_update_member->bind_param('s', $email_addr);
+            $stmt_update_member->execute();
+            $stmt_update_member->close();
+            error_log("✅ Marked $email_addr as sent in earthen_members_tb.");
         } else {
-            error_log("⚠️ No record found for $email_addr in tb_ecobrickers. No update was made.");
+            error_log("❌ Failed to update earthen_members_tb for $email_addr: " . $buwana_conn->error);
         }
     }
-
-    $stmt_update_status->close();
 
     // Respond with HTTP 200 to acknowledge the webhook
     http_response_code(200);

--- a/en/earthen-sender2.php
+++ b/en/earthen-sender2.php
@@ -112,13 +112,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['send_email']) && !$ha
     $subscriber_id = $_SESSION['locked_subscriber_id'] ?? null;
 
     if (!empty($email_html) && !empty($recipient_email) && $subscriber_id) {
+        // The webhook updates members once Mailgun confirms delivery
         try {
             if (sendEmail($recipient_email, $email_html)) {
-                // ✅ Mark as sent
-                $stmt = $buwana_conn->prepare("UPDATE earthen_members_tb SET test_sent = 1, test_sent_date_time = NOW() WHERE id = ?");
-                $stmt->bind_param("i", $subscriber_id);
-                $stmt->execute();
-                $stmt->close();
 
                 error_log("[EARTHEN] ✅ COMMITTED: {$recipient_email} by " . session_id());
 


### PR DESCRIPTION
## Summary
- add countdown mechanism before triggering auto send
- hide countdown after sending
- prevent duplicate auto-sends with `isSending` state
- mark newsletter members as sent only when Mailgun confirms delivery
- avoid downgrading webhook statuses

## Testing
- `php -l en/earthen-sender.php` *(fails: command not found)*
- `php -l en/earthen-sender2.php` *(fails: command not found)*
- `php -l emailing/webhook_handler.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d463cc48c83238448bfb985f7e1e0