### PR TITLE
Fix send-delay slider layout

### DIFF
--- a/en/earthen-sender.php
+++ b/en/earthen-sender.php
@@ -235,19 +235,18 @@ echo '<!DOCTYPE html>
     <div id="left-colum" style="width: 100%;">
         <label>✉️ Auto Send Emails</label>
         <p class="form-caption" style="margin-top:10px;">Uncheck to prevent the email from sending automatically after countdown.</p>
-    </div>
 
+        <label for="send-delay-slider" style="display:block;margin-top:20px;">⏱️ Send Delay</label>
+        <input type="range" id="send-delay-slider" min="1" max="10" value="5" step="1" style="width:100%;">
+    </div>
 
     <div id="right-column" style="width:100px; justify-content:center;">
         <label class="toggle-switch">
             <input type="checkbox" id="auto-send-toggle" value="1">
             <span class="slider"></span>
         </label>
+        <p style="text-align:center;margin-top:10px;font-weight:bold;">⏱️<span id="delay-display">5</span>s</p>
     </div>
-</div>
-<div class="form-row" style="margin-top:10px;">
-    <label for="send-delay-slider">⏱️ Send Delay: <span id="delay-display">5</span>s</label>
-    <input type="range" id="send-delay-slider" min="1" max="10" value="5" step="1" style="width:100%;">
 </div>
 
 


### PR DESCRIPTION
## Summary
- restructure the Auto Send form row so the send delay slider sits inside it
- move delay readout to the right column below the toggle switch

## Testing
- `php -l en/earthen-sender.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684d75c1a82c8323afbd613a2c66046d