### PR TITLE
Improve earthen sender robustness

### DIFF
--- a/scripts/log_sender_error.php
+++ b/scripts/log_sender_error.php
@@ -1,0 +1,8 @@
+<?php
+require_once '../buwanaconn_env.php';
+header('Content-Type: application/json');
+
+$msg = $_POST['message'] ?? 'Unknown error';
+error_log('[EARTHEN] ' . $msg);
+
+echo json_encode(['success' => true]);

--- a/scripts/mark_member_sent.php
+++ b/scripts/mark_member_sent.php
@@ -1,0 +1,26 @@
+<?php
+require_once '../buwanaconn_env.php';
+header('Content-Type: application/json');
+
+$id = isset($_POST['id']) ? intval($_POST['id']) : 0;
+$response = ['success' => false];
+
+if ($id > 0) {
+    $stmt = $buwana_conn->prepare("UPDATE earthen_members_tb SET test_sent = 1, processing = 1, test_sent_date_time = NOW() WHERE id = ?");
+    if ($stmt) {
+        $stmt->bind_param('i', $id);
+        if ($stmt->execute()) {
+            $response['success'] = true;
+        } else {
+            $response['error'] = $stmt->error;
+        }
+        $stmt->close();
+    } else {
+        $response['error'] = $buwana_conn->error;
+    }
+    error_log("[EARTHEN] Marked member $id as processed after repeated failures.");
+} else {
+    $response['error'] = 'Invalid ID';
+}
+
+echo json_encode($response);


### PR DESCRIPTION
## Summary
- tweak send-delay slider color to green
- gather email sending status in a datatable
- add JS error handling for failed sends
- mark problematic members as processed when repeatedly failing
- add server side helpers to log errors and mark members

## Testing
- `php -l scripts/mark_member_sent.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_684d9ec197e48323aa53cc3b4c30c9f8