### PR TITLE
Fix email status limit and add Material DataTables style

### DIFF
--- a/en/earthen-sender.php
+++ b/en/earthen-sender.php
@@ -94,8 +94,8 @@ $total_members = intval($row['total_members'] ?? 0);
 $sent_count = intval($row['sent_count'] ?? 0);
 $sent_percentage = ($total_members > 0) ? round(($sent_count / $total_members) * 100, 2) : 0;
 
-// Fetch the status of all members ordered by earliest sent date
-$query_status = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time FROM earthen_members_tb ORDER BY test_sent_date_time ASC";
+// Fetch the status of the first ten members ordered by earliest sent date
+$query_status = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time FROM earthen_members_tb ORDER BY test_sent_date_time ASC LIMIT 10";
 $status_result = $buwana_conn->query($query_status);
 $all_members = $status_result->fetch_all(MYSQLI_ASSOC);
 
@@ -257,6 +257,7 @@ echo '<!DOCTYPE html>
 
 
 
+<div id="send-controls" style="height:240px;">
 <form id="email-form" method="POST" style="margin-top: 50px;">
     <p><strong>From:</strong> <?php echo htmlspecialchars($email_from, ENT_QUOTES, 'UTF-8'); ?></p>
     <p><strong>Subject:</strong> <?php echo htmlspecialchars($email_subject, ENT_QUOTES, 'UTF-8'); ?></p>
@@ -287,12 +288,14 @@ echo '<!DOCTYPE html>
     <button type="button" id="stop-timer-btn" class="confirm-button delete">🛑 Stop Timer</button>
 </div>
 
+</div>
+
 
 
 
 
     <h3>Email Sending Status:</h3>
-    <table id="email-status-table" class="display responsive nowrap" style="width:100%">
+    <table id="email-status-table" class="display responsive nowrap mdl-data-table" style="width:100%">
         <thead>
             <tr>
                 <th>Name</th>
@@ -330,7 +333,8 @@ $(document).ready(function () {
 
     // Initialize DataTable for status overview
     $('#email-status-table').DataTable({
-        order: [[3, 'asc']]
+        order: [[3, 'asc']],
+        pageLength: 10
     });
     $("div.dataTables_filter input").attr('placeholder', 'Search emails...');
 

--- a/includes/admin-panel-inc.php
+++ b/includes/admin-panel-inc.php
@@ -14,6 +14,7 @@
 <!-- Include DataTables and jQuery Libraries -->
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.13.5/css/jquery.dataTables.min.css">
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/responsive/2.4.1/css/responsive.dataTables.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/plug-ins/1.13.5/integration/material/dataTables.material.min.css">
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/1.13.5/js/jquery.dataTables.min.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/responsive/2.4.1/js/dataTables.responsive.min.js"></script>

--- a/styles/main.css
+++ b/styles/main.css
@@ -2876,3 +2876,6 @@ padding: 10px;
 .feature-toggle:hover {
     cursor: pointer;
 }
+
+/* Material Design theme for DataTables */
+@import url('https://cdn.datatables.net/plug-ins/1.13.5/integration/material/dataTables.material.min.css');


### PR DESCRIPTION
## Summary
- limit sender status table to first 10 rows
- prevent layout jump by wrapping sender controls in a fixed-height container
- apply Material Design theme to DataTables via CDN
- reference Material CSS in main styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684da2d1a89c8323ae25649b64db99de