### PR TITLE
Improve email status table and dark mode

### DIFF
--- a/en/earthen-sender.php
+++ b/en/earthen-sender.php
@@ -94,10 +94,23 @@ $total_members = intval($row['total_members'] ?? 0);
 $sent_count = intval($row['sent_count'] ?? 0);
 $sent_percentage = ($total_members > 0) ? round(($sent_count / $total_members) * 100, 2) : 0;
 
-// Fetch the status of the first ten members ordered by earliest sent date
-$query_status = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time FROM earthen_members_tb ORDER BY test_sent_date_time ASC LIMIT 10";
-$status_result = $buwana_conn->query($query_status);
-$all_members = $status_result->fetch_all(MYSQLI_ASSOC);
+// Fetch the last four sent members and the remaining pending ones
+$query_sent = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
+               FROM earthen_members_tb
+               WHERE test_sent = 1
+               ORDER BY test_sent_date_time DESC
+               LIMIT 4";
+$sent_result = $buwana_conn->query($query_sent);
+$sent_members = $sent_result->fetch_all(MYSQLI_ASSOC);
+
+$query_pending = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
+                  FROM earthen_members_tb
+                  WHERE test_sent = 0
+                  ORDER BY id ASC";
+$pending_result = $buwana_conn->query($query_pending);
+$pending_members = $pending_result->fetch_all(MYSQLI_ASSOC);
+
+$all_members = array_merge($sent_members, $pending_members);
 
 
 require_once 'live-newsletter.php';  //the newsletter html
@@ -332,11 +345,28 @@ $(document).ready(function () {
     const hasAlerts = <?php echo $has_alerts ? 'true' : 'false'; ?>;
 
     // Initialize DataTable for status overview
-    $('#email-status-table').DataTable({
-        order: [[3, 'asc']],
+    const statusTable = $('#email-status-table').DataTable({
+        order: [],
         pageLength: 10
     });
     $("div.dataTables_filter input").attr('placeholder', 'Search emails...');
+
+    function refreshStatusTable() {
+        $.getJSON('../scripts/get_email_status.php', function(resp) {
+            if (resp.success) {
+                const rows = resp.members.map(m => [
+                    m.name,
+                    m.email,
+                    m.email_open_rate || '0%',
+                    m.test_sent_date_time || 'N/A',
+                    m.test_sent == 1 ? '✅' : '❌'
+                ]);
+                statusTable.clear().rows.add(rows).draw(false);
+            }
+        });
+    }
+
+    refreshStatusTable();
 
     const autoSendEnabled = () => $('#auto-send-toggle').is(':checked');
     const testSendEnabled = () => $('#test-email-toggle').is(':checked');
@@ -424,6 +454,7 @@ function fetchNextRecipient() {
                 }
 
                 updateVisibleButton();
+                refreshStatusTable();
 
                 // 🟢 Auto-send the next email if enabled
                 if ($('#auto-send-toggle').is(':checked')) {

--- a/scripts/get_email_status.php
+++ b/scripts/get_email_status.php
@@ -1,0 +1,27 @@
+<?php
+require_once '../buwanaconn_env.php';
+header('Content-Type: application/json');
+
+try {
+    $sent_sql = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
+                  FROM earthen_members_tb
+                  WHERE test_sent = 1
+                  ORDER BY test_sent_date_time DESC
+                  LIMIT 4";
+    $sent_res = $buwana_conn->query($sent_sql);
+    $sent_members = $sent_res ? $sent_res->fetch_all(MYSQLI_ASSOC) : [];
+
+    $pending_sql = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
+                     FROM earthen_members_tb
+                     WHERE test_sent = 0
+                     ORDER BY id ASC";
+    $pending_res = $buwana_conn->query($pending_sql);
+    $pending_members = $pending_res ? $pending_res->fetch_all(MYSQLI_ASSOC) : [];
+
+    $all_members = array_merge($sent_members, $pending_members);
+
+    echo json_encode(['success' => true, 'members' => $all_members]);
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}
+?>

--- a/styles/mode-dark.css
+++ b/styles/mode-dark.css
@@ -61,11 +61,11 @@
 
 
 
-  --table-background-1: #4d4c4c;
-  --table-background-2: #454545;
+  --table-background-1: #2f2f2f;
+  --table-background-2: #1f1f1f;
 
 
-  --table-background-hover: #333333;
+  --table-background-hover: #3d3d3d;
 
   --table-background-heading: #0868AD;
 


### PR DESCRIPTION
## Summary
- contrast dataTables rows in dark mode
- show last four sent members first, then pending recipients
- refresh the email status DataTable after each send
- add script for getting the latest status list

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_684da90271748323bec81585dd8ea6d1