### PR TITLE
Fix earthen-sender table overflow

### DIFF
--- a/en/earthen-sender.php
+++ b/en/earthen-sender.php
@@ -95,20 +95,27 @@ $sent_count = intval($row['sent_count'] ?? 0);
 $sent_percentage = ($total_members > 0) ? round(($sent_count / $total_members) * 100, 2) : 0;
 
 // Fetch the last four sent members and the remaining pending ones
+$status_limit = 20; // total rows to display in the status table
+$sent_limit = 4;    // number of most recent sent entries
+
 $query_sent = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
                FROM earthen_members_tb
                WHERE test_sent = 1
                ORDER BY test_sent_date_time DESC
-               LIMIT 4";
+               LIMIT {$sent_limit}";
 $sent_result = $buwana_conn->query($query_sent);
-$sent_members = $sent_result->fetch_all(MYSQLI_ASSOC);
+$sent_members = $sent_result ? $sent_result->fetch_all(MYSQLI_ASSOC) : [];
+$sent_count = count($sent_members);
+
+$pending_limit = $status_limit - $sent_count;
 
 $query_pending = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
                   FROM earthen_members_tb
                   WHERE test_sent = 0
-                  ORDER BY id ASC";
+                  ORDER BY id ASC
+                  LIMIT {$pending_limit}";
 $pending_result = $buwana_conn->query($query_pending);
-$pending_members = $pending_result->fetch_all(MYSQLI_ASSOC);
+$pending_members = $pending_result ? $pending_result->fetch_all(MYSQLI_ASSOC) : [];
 
 $all_members = array_merge($sent_members, $pending_members);
 

--- a/scripts/get_email_status.php
+++ b/scripts/get_email_status.php
@@ -3,18 +3,25 @@ require_once '../buwanaconn_env.php';
 header('Content-Type: application/json');
 
 try {
+    $status_limit = 20;
+    $sent_limit = 4;
+
     $sent_sql = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
                   FROM earthen_members_tb
                   WHERE test_sent = 1
                   ORDER BY test_sent_date_time DESC
-                  LIMIT 4";
+                  LIMIT {$sent_limit}";
     $sent_res = $buwana_conn->query($sent_sql);
     $sent_members = $sent_res ? $sent_res->fetch_all(MYSQLI_ASSOC) : [];
+    $sent_count = count($sent_members);
+
+    $pending_limit = $status_limit - $sent_count;
 
     $pending_sql = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
                      FROM earthen_members_tb
                      WHERE test_sent = 0
-                     ORDER BY id ASC";
+                     ORDER BY id ASC
+                     LIMIT {$pending_limit}";
     $pending_res = $buwana_conn->query($pending_sql);
     $pending_members = $pending_res ? $pending_res->fetch_all(MYSQLI_ASSOC) : [];
 


### PR DESCRIPTION
## Summary
- limit the status table to only show 20 members
- update helper API to return only 20 results total

## Testing
- `ls scripts | head`

------
https://chatgpt.com/codex/tasks/task_b_684daabf263c83238b1001bdd944162c