### PR TITLE
Fix duplicate email sending

### DIFF
--- a/emailing/webhook_handler.php
+++ b/emailing/webhook_handler.php
@@ -149,7 +149,7 @@ if (stripos($response_message, "rate limited") !== false || stripos($response_me
     // If Mailgun confirms delivery or a failure event, mark the member as processed
     if ($basic_mailgun_status === 'delivered' || in_array($basic_mailgun_status, $failure_events)) {
         $stmt_update_member = $buwana_conn->prepare(
-            "UPDATE earthen_members_tb SET test_sent = 1, test_sent_date_time = NOW() WHERE email = ? AND test_sent = 0"
+            "UPDATE earthen_members_tb SET test_sent = 1, processing = 1, test_sent_date_time = NOW() WHERE email = ? AND test_sent = 0"
         );
         if ($stmt_update_member) {
             $stmt_update_member->bind_param('s', $email_addr);

--- a/scripts/get_next_recipient.php
+++ b/scripts/get_next_recipient.php
@@ -36,8 +36,7 @@ try {
     $query = "
         SELECT id, email, name
         FROM earthen_members_tb
-        WHERE test_sent = 0
-
+        WHERE test_sent = 0 AND processing = 0
         ORDER BY id ASC
         LIMIT 1
         FOR UPDATE
@@ -48,6 +47,15 @@ try {
     if ($result && $result->num_rows > 0) {
         $subscriber = $result->fetch_assoc();
         $_SESSION['locked_subscriber_id'] = $subscriber['id'];
+
+        // Mark this subscriber as processing to avoid duplicates
+        $update_sql = "UPDATE earthen_members_tb SET processing = 1 WHERE id = ?";
+        $stmt_update = $buwana_conn->prepare($update_sql);
+        if ($stmt_update) {
+            $stmt_update->bind_param('i', $subscriber['id']);
+            $stmt_update->execute();
+            $stmt_update->close();
+        }
 
         // ✅ Commit lock early
         $buwana_conn->commit();


### PR DESCRIPTION
## Summary
- prevent selecting the same recipient repeatedly
- mark recipients as processing in the database to avoid duplication
- mark processing in webhook updates

## Testing
- `php -l emailing/webhook_handler.php` *(fails: `php` not found)*


------
https://chatgpt.com/codex/tasks/task_b_684e329f1fe883238b5033bb15d59b9e