### PR TITLE
Fix processing flag reset

### DIFF
--- a/emailing/webhook_handler.php
+++ b/emailing/webhook_handler.php
@@ -149,8 +149,9 @@ if (stripos($response_message, "rate limited") !== false || stripos($response_me
 
     // If Mailgun confirms delivery or a failure event, mark the member as processed
     if ($basic_mailgun_status === 'delivered' || in_array($basic_mailgun_status, $failure_events)) {
+        // Mark subscriber as sent and release the processing flag
         $stmt_update_member = $buwana_conn->prepare(
-            "UPDATE earthen_members_tb SET test_sent = 1, processing = 1, test_sent_date_time = NOW() WHERE email = ? AND test_sent = 0"
+            "UPDATE earthen_members_tb SET test_sent = 1, processing = 0, test_sent_date_time = NOW() WHERE email = ? AND test_sent = 0"
         );
         if ($stmt_update_member) {
             $stmt_update_member->bind_param('s', $email_addr);

--- a/scripts/mark_member_sent.php
+++ b/scripts/mark_member_sent.php
@@ -6,7 +6,8 @@ $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
 $response = ['success' => false];
 
 if ($id > 0) {
-    $stmt = $buwana_conn->prepare("UPDATE earthen_members_tb SET test_sent = 1, processing = 1, test_sent_date_time = NOW() WHERE id = ?");
+    // Mark the subscriber as sent and clear the processing flag
+    $stmt = $buwana_conn->prepare("UPDATE earthen_members_tb SET test_sent = 1, processing = 0, test_sent_date_time = NOW() WHERE id = ?");
     if ($stmt) {
         $stmt->bind_param('i', $id);
         if ($stmt->execute()) {


### PR DESCRIPTION
## Summary
- ensure we clear the `processing` flag after an email is processed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684fb307a0e483238364e0a184cee9fc