### PR TITLE
Fix Earthen sender processing flag logic

### DIFF
--- a/scripts/mark_member_sent.php
+++ b/scripts/mark_member_sent.php
@@ -6,8 +6,8 @@ $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
 $response = ['success' => false];
 
 if ($id > 0) {
-    // Mark the subscriber as sent and clear the processing flag
-    $stmt = $buwana_conn->prepare("UPDATE earthen_members_tb SET test_sent = 1, processing = 0, test_sent_date_time = NOW() WHERE id = ?");
+    // Mark the subscriber as failed
+    $stmt = $buwana_conn->prepare("UPDATE earthen_members_tb SET processing = 2 WHERE id = ?");
     if ($stmt) {
         $stmt->bind_param('i', $id);
         if ($stmt->execute()) {
@@ -19,7 +19,7 @@ if ($id > 0) {
     } else {
         $response['error'] = $buwana_conn->error;
     }
-    error_log("[EARTHEN] Marked member $id as processed after repeated failures.");
+    error_log("[EARTHEN] Marked member $id as failed after repeated attempts.");
 } else {
     $response['error'] = 'Invalid ID';
 }


### PR DESCRIPTION
## Summary
- make get_next_recipient return existing processing record and only mark when queued
- mark row as queued on send and mark failed attempts with processing=2
- adjust JS to stop retry loops and mark failures
- update webhook to store failed status instead of marking as sent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6850e40f8a0c83239f55a46ec4a150f6