### PR TITLE
Order pending emails by created_at

### DIFF
--- a/en/earthen-sender.php
+++ b/en/earthen-sender.php
@@ -111,8 +111,8 @@ $pending_limit = $status_limit - $sent_count;
 
 $query_pending = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
                   FROM earthen_members_tb
-                  WHERE test_sent = 0
-                  ORDER BY id ASC
+                  WHERE test_sent = 0 AND processing IS NULL
+                  ORDER BY created_at ASC
                   LIMIT {$pending_limit}";
 $pending_result = $buwana_conn->query($query_pending);
 $pending_members = $pending_result ? $pending_result->fetch_all(MYSQLI_ASSOC) : [];

--- a/scripts/get_email_status.php
+++ b/scripts/get_email_status.php
@@ -19,8 +19,8 @@ try {
 
     $pending_sql = "SELECT id, email, name, email_open_rate, test_sent, test_sent_date_time
                      FROM earthen_members_tb
-                     WHERE test_sent = 0
-                     ORDER BY id ASC
+                     WHERE test_sent = 0 AND processing IS NULL
+                     ORDER BY created_at ASC
                      LIMIT {$pending_limit}";
     $pending_res = $buwana_conn->query($pending_sql);
     $pending_members = $pending_res ? $pending_res->fetch_all(MYSQLI_ASSOC) : [];

--- a/scripts/get_next_recipient.php
+++ b/scripts/get_next_recipient.php
@@ -38,7 +38,7 @@ try {
         SELECT id, email, name
         FROM earthen_members_tb
         WHERE test_sent = 0 AND processing = 1
-        ORDER BY id ASC
+        ORDER BY created_at ASC
         LIMIT 1
         FOR UPDATE
     ";
@@ -73,8 +73,8 @@ try {
         $new_sql = "
             SELECT id, email, name
             FROM earthen_members_tb
-            WHERE test_sent = 0 AND processing = 0
-            ORDER BY id ASC
+            WHERE test_sent = 0 AND processing IS NULL
+            ORDER BY created_at ASC
             LIMIT 1
             FOR UPDATE
         ";


### PR DESCRIPTION
## Summary
- fetch earliest members when selecting recipients for earthen sender
- only queue unsent members with `processing` null

## Testing
- `php -l en/earthen-sender.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68516619e5f88323888c80f342160533