### PR TITLE
Fix editing of training to preserve data

### DIFF
--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -609,6 +609,11 @@ if (!empty($community_id)) {
     <input type="hidden" id="training_id" name="training_id" value="<?php echo htmlspecialchars($training_id ?? '', ENT_QUOTES, 'UTF-8'); ?>">
 
     <!-- ======================= Submit Button ======================= -->
+    <?php if ($editing): ?>
+    <div>
+        <button type='submit' id='save-progress' class='confirm-button' style='background:grey;width: 100%;margin: 30px 0px -15px 0px;'>💾 Save Progress</button>
+    </div>
+    <?php endif; ?>
     <div>
         <input type="submit" value="<?php echo $editing ? '💾 Save Changes to Training' : '➕ Create Training!'; ?>" data-lang-id="100-submit-report-1">
     </div>

--- a/en/launch-training_process.php
+++ b/en/launch-training_process.php
@@ -23,6 +23,17 @@ if ($training_id <= 0 && isset($_GET['id'])) {
 }
 $editing = ($training_id > 0);
 
+// Default to existing values for certain fields when not posted
+$existing_summary = $existing_success = $existing_challenges = $existing_lessons = '';
+if ($editing) {
+    $stmt_existing = $gobrik_conn->prepare("SELECT training_summary, training_success, training_challenges, training_lessons_learned FROM tb_trainings WHERE training_id=?");
+    $stmt_existing->bind_param("i", $training_id);
+    $stmt_existing->execute();
+    $stmt_existing->bind_result($existing_summary, $existing_success, $existing_challenges, $existing_lessons);
+    $stmt_existing->fetch();
+    $stmt_existing->close();
+}
+
 $training_title = trim($_POST['training_title'] ?? '');
 $training_subtitle = trim($_POST['training_subtitle'] ?? '');
 $training_date = trim($_POST['training_date'] ?? '');
@@ -41,11 +52,11 @@ $ready_to_show = isset($_POST['ready_to_show']) ? 1 : 0;
 $show_report = isset($_POST['show_report']) ? 1 : 0;
 $show_signup_count = isset($_POST['show_signup_count']) ? 1 : 0;
 $featured_description = trim($_POST['featured_description'] ?? '');
-$training_summary = trim($_POST['training_summary'] ?? '');
+$training_summary = isset($_POST['training_summary']) ? trim($_POST['training_summary']) : $existing_summary;
 $training_agenda = trim($_POST['training_agenda'] ?? '');
-$training_success = trim($_POST['training_success'] ?? '');
-$training_challenges = trim($_POST['training_challenges'] ?? '');
-$training_lessons_learned = trim($_POST['training_lessons_learned'] ?? '');
+$training_success = isset($_POST['training_success']) ? trim($_POST['training_success']) : $existing_success;
+$training_challenges = isset($_POST['training_challenges']) ? trim($_POST['training_challenges']) : $existing_challenges;
+$training_lessons_learned = isset($_POST['training_lessons_learned']) ? trim($_POST['training_lessons_learned']) : $existing_lessons;
 $training_location = trim($_POST['training_location'] ?? '');
 $training_type = trim($_POST['training_type'] ?? '');
 $training_language = trim($_POST['training_language'] ?? 'en');


### PR DESCRIPTION
## Summary
- update `launch-training_process.php` so that missing fields do not overwrite existing values
- add a Save Progress button at the bottom of `launch-training.php` when editing

## Testing
- `php -l en/launch-training.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858309b30e0832b89c48b9bc9c1ddc2