### PR TITLE
Use newest unsent users for Buwana sender

### DIFF
--- a/en/buwana-sender.php
+++ b/en/buwana-sender.php
@@ -112,7 +112,7 @@ $pending_limit = $status_limit - $sent_count;
 $query_pending = "SELECT buwana_id AS id, email, full_name AS name, bot_score, test_sent, test_sent_date_time
                  FROM users_tb
                  WHERE test_sent = 0 AND processing IS NULL
-                 ORDER BY created_at ASC
+                ORDER BY created_at DESC
                  LIMIT {$pending_limit}";
 $pending_result = $buwana_conn->query($query_pending);
 $pending_members = $pending_result ? $pending_result->fetch_all(MYSQLI_ASSOC) : [];

--- a/scripts/get_buwana_email_status.php
+++ b/scripts/get_buwana_email_status.php
@@ -20,7 +20,7 @@ try {
     $pending_sql = "SELECT buwana_id AS id, email, full_name AS name, bot_score, test_sent, test_sent_date_time
                     FROM users_tb
                     WHERE test_sent = 0 AND processing IS NULL
-                    ORDER BY created_at ASC
+                    ORDER BY created_at DESC
                     LIMIT {$pending_limit}";
     $pending_res = $buwana_conn->query($pending_sql);
     $pending_members = $pending_res ? $pending_res->fetch_all(MYSQLI_ASSOC) : [];

--- a/scripts/get_next_buwana_recipient.php
+++ b/scripts/get_next_buwana_recipient.php
@@ -38,7 +38,7 @@ try {
         SELECT buwana_id AS id, email, full_name AS name
         FROM users_tb
         WHERE test_sent = 0 AND processing = 1
-        ORDER BY created_at ASC
+        ORDER BY created_at DESC
         LIMIT 1
         FOR UPDATE
     ";
@@ -74,7 +74,7 @@ try {
             SELECT buwana_id AS id, email, full_name AS name
             FROM users_tb
             WHERE test_sent = 0 AND processing IS NULL
-            ORDER BY created_at ASC
+            ORDER BY created_at DESC
             LIMIT 1
             FOR UPDATE
         ";


### PR DESCRIPTION
## Summary
- adjust Buwana sender to list pending users newest first
- update status endpoint to match new order
- select newest unsent subscriber when locking the next recipient

## Testing
- `php -l en/buwana-sender.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb9b75608832b97822076360ee145