### PR TITLE
Remove aliases from Buwana sender scripts

### DIFF
--- a/en/buwana-sender.php
+++ b/en/buwana-sender.php
@@ -98,7 +98,7 @@ $sent_percentage = ($total_members > 0) ? round(($sent_count / $total_members) *
 $status_limit = 20; // total rows to display in the status table
 $sent_limit = 4;    // number of most recent sent entries
 
-$query_sent = "SELECT buwana_id AS id, email, full_name AS name, bot_score, test_sent, test_sent_date_time
+$query_sent = "SELECT buwana_id, email, full_name, bot_score, test_sent, test_sent_date_time
                FROM users_tb
                WHERE test_sent = 1
                ORDER BY test_sent_date_time DESC
@@ -109,7 +109,7 @@ $sent_count = count($sent_members);
 
 $pending_limit = $status_limit - $sent_count;
 
-$query_pending = "SELECT buwana_id AS id, email, full_name AS name, bot_score, test_sent, test_sent_date_time
+$query_pending = "SELECT buwana_id, email, full_name, bot_score, test_sent, test_sent_date_time
                  FROM users_tb
                  WHERE test_sent = 0 AND processing IS NULL
                 ORDER BY created_at DESC
@@ -385,7 +385,7 @@ echo '<!DOCTYPE html>
         <tbody>
             <?php foreach ($all_members as $member): ?>
                 <tr>
-                    <td><?php echo htmlspecialchars($member['name']); ?></td>
+                    <td><?php echo htmlspecialchars($member['full_name']); ?></td>
                     <td><?php echo htmlspecialchars($member['email']); ?></td>
                     <td><?php echo $member['bot_score'] ?? '0'; ?></td>
                     <td><?php echo $member['test_sent_date_time'] ?? 'N/A'; ?></td>
@@ -463,7 +463,7 @@ $(document).ready(function () {
         $.getJSON('../scripts/get_buwana_email_status.php', function(resp) {
             if (resp.success) {
                 const rows = resp.members.map(m => [
-                    m.name,
+                    m.full_name,
                     m.email,
                     m.bot_score || '0',
                     m.test_sent_date_time || 'N/A',
@@ -547,8 +547,8 @@ function fetchNextRecipient() {
                 // 🎯 Set recipient
                 const sub = response.subscriber;
                 recipientEmail = sub?.email || '';
-                recipientName = sub?.name || '';
-                recipientId = sub?.id || null;
+                recipientName = sub?.full_name || '';
+                recipientId = sub?.buwana_id || null;
 
                 console.log("📋 Next recipient:", recipientEmail);
 

--- a/scripts/get_buwana_email_status.php
+++ b/scripts/get_buwana_email_status.php
@@ -6,7 +6,7 @@ try {
     $status_limit = 20;
     $sent_limit = 4;
 
-    $sent_sql = "SELECT buwana_id AS id, email, full_name AS name, bot_score, test_sent, test_sent_date_time
+    $sent_sql = "SELECT buwana_id, email, full_name, bot_score, test_sent, test_sent_date_time
                    FROM users_tb
                    WHERE test_sent = 1
                    ORDER BY test_sent_date_time DESC
@@ -17,7 +17,7 @@ try {
 
     $pending_limit = $status_limit - $sent_count;
 
-    $pending_sql = "SELECT buwana_id AS id, email, full_name AS name, bot_score, test_sent, test_sent_date_time
+    $pending_sql = "SELECT buwana_id, email, full_name, bot_score, test_sent, test_sent_date_time
                     FROM users_tb
                     WHERE test_sent = 0 AND processing IS NULL
                     ORDER BY created_at DESC

--- a/scripts/get_next_buwana_recipient.php
+++ b/scripts/get_next_buwana_recipient.php
@@ -35,7 +35,7 @@ try {
 
     // First check if there is already a recipient marked as processing
     $processing_sql = "
-        SELECT buwana_id AS id, email, full_name AS name
+        SELECT buwana_id, email, full_name
         FROM users_tb
         WHERE test_sent = 0 AND processing = 1
         ORDER BY created_at DESC
@@ -47,7 +47,7 @@ try {
 
     if ($result && $result->num_rows > 0) {
         $subscriber = $result->fetch_assoc();
-        $_SESSION['locked_subscriber_id'] = $subscriber['id'];
+        $_SESSION['locked_subscriber_id'] = $subscriber['buwana_id'];
 
         // Commit lock
         $buwana_conn->commit();
@@ -71,7 +71,7 @@ try {
     } else {
         // No current processing recipient, fetch a new one
         $new_sql = "
-            SELECT buwana_id AS id, email, full_name AS name
+            SELECT buwana_id, email, full_name
             FROM users_tb
             WHERE test_sent = 0 AND processing IS NULL
             ORDER BY created_at DESC
@@ -83,7 +83,7 @@ try {
 
         if ($new_res && $new_res->num_rows > 0) {
             $subscriber = $new_res->fetch_assoc();
-            $_SESSION['locked_subscriber_id'] = $subscriber['id'];
+            $_SESSION['locked_subscriber_id'] = $subscriber['buwana_id'];
 
             $buwana_conn->commit();
 


### PR DESCRIPTION
## Summary
- remove column aliases from `get_next_buwana_recipient.php`
- update `buwana-sender.php` queries and JS handlers for new keys
- update `get_buwana_email_status.php` to return unaliased column names

## Testing
- `php -l scripts/get_next_buwana_recipient.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf577e4c832b920e3e8a48eaab28