### PR TITLE
Fix buwana-sender auto-send toggle

### DIFF
--- a/en/buwana-sender.php
+++ b/en/buwana-sender.php
@@ -645,7 +645,7 @@ function sendEmail() {
                 send_email: "1",
                 email_to: targetEmail,
                 email_html: emailBody,
-                test_mode: isTestMode ? 1 : 0
+                test_mode: isTestMode ? 1 : 0,
                 subscriber_id: recipientId
             },
             success: function (resp) {


### PR DESCRIPTION
## Summary
- fix missing comma in JS AJAX payload in `buwana-sender.php`

## Testing
- `php -l en/buwana-sender.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bcd9eec00832b821e8148437ca199