### PR TITLE
Fix duplicate recipients in fetch

### DIFF
--- a/scripts/get_next_recipient.php
+++ b/scripts/get_next_recipient.php
@@ -50,6 +50,16 @@ try {
     if ($result && $result->num_rows > 0) {
         $subscriber = $result->fetch_assoc();
 
+        // Mark the record as being processed to avoid duplicate fetches
+        $update = $buwana_conn->prepare(
+            "UPDATE earthen_members_tb SET processing = 1 WHERE id = ?"
+        );
+        if ($update) {
+            $update->bind_param('i', $subscriber['id']);
+            $update->execute();
+            $update->close();
+        }
+
         $buwana_conn->commit();
 
         // Fetch updated stats


### PR DESCRIPTION
## Summary
- mark a subscriber's record as `processing=1` in `get_next_recipient.php`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ccbd603e0832bacf65add58500037