### PR TITLE
Add JWT verification to secured pages

### DIFF
--- a/en/accounting.php
+++ b/en/accounting.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 require '../vendor/autoload.php'; // Path to Composer's autoloader
 
 // Set page variables

--- a/en/add-images_process.php
+++ b/en/add-images_process.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php';
-startSecureSession();
+require_once '../auth/session_start.php';
 
 header('Content-Type: application/json');
 

--- a/en/add-training-images.php
+++ b/en/add-training-images.php
@@ -3,6 +3,7 @@ ini_set('display_errors', 1);
 error_reporting(E_ALL);
 ini_set('memory_limit', '256M'); // Increase memory limit
 require_once '../earthenAuth_helper.php'; // Authentication helper
+require_once '../auth/session_start.php';
 
 // PART 1: Set page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));

--- a/en/add-training_process.php
+++ b/en/add-training_process.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php';
-startSecureSession();
+require_once '../auth/session_start.php';
 
 if (!isLoggedIn()) {
     echo json_encode(['success' => false, 'error' => 'Unauthorized']);

--- a/en/admin-emailer.php
+++ b/en/admin-emailer.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 require '../vendor/autoload.php'; // Path to Composer's autoloader
 
 use GuzzleHttp\Client;

--- a/en/admin-panel.php
+++ b/en/admin-panel.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Set page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));

--- a/en/admin-review.php
+++ b/en/admin-review.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Set page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));

--- a/en/bug-report.php
+++ b/en/bug-report.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
@@ -7,7 +8,6 @@ $version = '0.14';
 $page = 'bug-report';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
-//startSecureSession(); // Start a secure session with regeneration to prevent session fixation
 
 // Check if user is logged in and session active
 if ($is_logged_in) {

--- a/en/buwana-sender.php
+++ b/en/buwana-sender.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Authentication helper
+require_once '../auth/session_start.php';
 require '../vendor/autoload.php'; // Composer autoload
 
 use GuzzleHttp\Client;
@@ -12,7 +13,6 @@ $page = 'admin-panel';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
 
-startSecureSession(); // Start a secure session with regeneration to prevent session fixation
 
 
 // Check if user is logged in and session active

--- a/en/dashboard-old.php
+++ b/en/dashboard-old.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
@@ -7,7 +8,6 @@ $version = '0.61';
 $page = 'dashboard';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
-startSecureSession(); // Start a secure session with regeneration to prevent session fixation
 
 
 // Check if user is logged in and session active

--- a/en/double_delete_account.php
+++ b/en/double_delete_account.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once '../auth/session_start.php';
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 

--- a/en/earthen-sender.php
+++ b/en/earthen-sender.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Authentication helper
+require_once '../auth/session_start.php';
 require '../vendor/autoload.php'; // Composer autoload
 
 use GuzzleHttp\Client;
@@ -12,7 +13,6 @@ $page = 'admin-panel';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
 
-startSecureSession(); // Start a secure session with regeneration to prevent session fixation
 
 
 // Check if user is logged in and session active

--- a/en/earthen-sender2.php
+++ b/en/earthen-sender2.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Authentication helper
+require_once '../auth/session_start.php';
 require '../vendor/autoload.php'; // Composer autoload
 
 use GuzzleHttp\Client;
@@ -12,7 +13,6 @@ $page = 'admin-panel';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
 
-startSecureSession(); // Start a secure session with regeneration to prevent session fixation
 
 
 // Check if user is logged in and session active

--- a/en/finalizer.php
+++ b/en/finalizer.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));

--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once '../earthenAuth_helper.php'; // Authentication helper
+require_once '../auth/session_start.php';
 
 // PART 1: Set page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));

--- a/en/launch-training_process.php
+++ b/en/launch-training_process.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php';
-startSecureSession();
+require_once '../auth/session_start.php';
 
 if (!isLoggedIn()) {
     echo json_encode(['success' => false, 'error' => 'Unauthorized']);

--- a/en/log-2.php
+++ b/en/log-2.php
@@ -1,6 +1,7 @@
 <?php
 ob_start(); // Start output buffering
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));

--- a/en/log-3.php
+++ b/en/log-3.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Ensure the user is logged in (handled by $is_logged_in from helper)
 if (!$is_logged_in) {

--- a/en/log-old.php
+++ b/en/log-old.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // PART 1: Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
@@ -7,7 +8,6 @@ $version = '0.545';
 $page = 'log';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
-startSecureSession(); // Start a secure session with regeneration to prevent session fixation
 
 // PART 2: Check if user is logged in and session active
 if ($is_logged_in) {

--- a/en/log.php
+++ b/en/log.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // PART 1: Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
@@ -7,7 +8,6 @@ $version = '0.546';
 $page = 'log';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
-startSecureSession(); // Start a secure session with regeneration to prevent session fixation
 
 // PART 2: Check if user is logged in and session active
 if ($is_logged_in) {

--- a/en/log_process.php
+++ b/en/log_process.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php';
-startSecureSession();
+require_once '../auth/session_start.php';
 
 if (!isset($_SESSION['buwana_id'])) {
     header('Location: login.php');

--- a/en/manage-subscriptions.php
+++ b/en/manage-subscriptions.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // PART 1: Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
@@ -7,7 +8,6 @@ $version = '0.544';
 $page = 'manage-subscriptions';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
-startSecureSession(); // Start a secure session with regeneration to prevent session fixation
 
 // PART 2: Check if user is logged in and session active
 if ($is_logged_in) {

--- a/en/messenger.php
+++ b/en/messenger.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
@@ -7,7 +8,6 @@ $version = '0.15';
 $page = 'messenger';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
-//startSecureSession(); // Start a secure session with regeneration to prevent session fixation
 
 // Check if user is logged in and session active
 if ($is_logged_in) {

--- a/en/profile.php
+++ b/en/profile.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));

--- a/en/profile_update_process.php
+++ b/en/profile_update_process.php
@@ -1,6 +1,7 @@
 <?php
 
 session_start();
+require_once '../auth/session_start.php';
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 

--- a/en/registration_confirmation.php
+++ b/en/registration_confirmation.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php';
+require_once '../auth/session_start.php';
 require '../vendor/autoload.php';
 
 use GuzzleHttp\Client;

--- a/en/training-report.php
+++ b/en/training-report.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once '../earthenAuth_helper.php'; // Authentication helper
+require_once '../auth/session_start.php';
 
 // PART 1: Set page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));

--- a/en/update_last_name.php
+++ b/en/update_last_name.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once '../auth/session_start.php';
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
 

--- a/en/validate-1.php
+++ b/en/validate-1.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME'])) ?? 'en';

--- a/en/validate.php
+++ b/en/validate.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
+require_once '../auth/session_start.php';
 
 // Ensure the user is logged in (handled by $is_logged_in from helper)
 if (!$is_logged_in) {


### PR DESCRIPTION
## Summary
- include `auth/session_start.php` on all auth-required pages
- ensure JWT verification for page access

## Testing
- `php -l en/accounting.php`
- `php -l en/validate.php`


------
https://chatgpt.com/codex/tasks/task_e_6870c342221c832ba6c7fa988f90ac83