### PR TITLE
Fix placeholder substitution in trainee email

### DIFF
--- a/processes/trainee_sender.php
+++ b/processes/trainee_sender.php
@@ -80,7 +80,12 @@ Alright, see you soon!
 EOT;
 
     if ($override !== '') {
-        $body = $override;
+        // Replace any $first_name placeholder in the custom message
+        $body = str_replace([
+            '$first_name',
+            '{first_name}',
+            '{$first_name}'
+        ], $first_name, $override);
     }
 
     $html = nl2br($body);


### PR DESCRIPTION
## Summary
- fix custom email message to replace `$first_name` placeholders

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_68788a936eac832bbc6e7e5f54da5056