### PR TITLE
Fix create training display

### DIFF
--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -486,6 +486,8 @@ if (!empty($community_id)) {
            </p>
        </div>
 
+   <?php if ($editing): ?>
+
    <br><hr><br>
 
    <h4>Training Feature Images</h4>
@@ -623,6 +625,7 @@ if (!empty($community_id)) {
         </label>
 
     </div>
+    <?php endif; ?>
 
     <!-- Hidden Training ID -->
     <input type="hidden" id="training_id" name="training_id" value="<?php echo htmlspecialchars($training_id ?? '', ENT_QUOTES, 'UTF-8'); ?>">


### PR DESCRIPTION
## Summary
- hide feature image, costing and toggle sections until a training exists

## Testing
- `php -l en/launch-training.php`
- `php -l en/launch-training_process.php`


------
https://chatgpt.com/codex/tasks/task_e_6878b3b1f210832bb857419e72c5bcb3