### PR TITLE
Add Earthcal event URL input to training form

### DIFF
--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -124,6 +124,7 @@ $training_subtitle = '';
 $training_time_txt = '';
 $registration_scope = '';
 $trainer_contact_email = '';
+$earthcal_event_url = '';
 $show_report = 0;
 $show_signup_count = 0;
 
@@ -133,7 +134,7 @@ if ($editing) {
                   training_type, training_language, briks_made, avg_brik_weight, training_location,
                   training_summary, training_agenda, training_success, training_challenges, training_lessons_learned,
                   youtube_result_video, moodle_url, ready_to_show, show_report, show_signup_count, featured_description, community_id,
-                  zoom_link, zoom_link_full, feature_photo1_main, feature_photo1_tmb, feature_photo2_main, feature_photo2_tmb, feature_photo3_main, feature_photo3_tmb, registration_scope, trainer_contact_email
+                  zoom_link, zoom_link_full, earthcal_event_url, feature_photo1_main, feature_photo1_tmb, feature_photo2_main, feature_photo2_tmb, feature_photo3_main, feature_photo3_tmb, registration_scope, trainer_contact_email
                   FROM tb_trainings WHERE training_id = ?";
 
     $stmt_fetch = $gobrik_conn->prepare($sql_fetch);
@@ -143,7 +144,7 @@ if ($editing) {
                             $training_type, $training_language, $briks_made, $avg_brik_weight, $training_location,
                             $training_summary, $training_agenda, $training_success, $training_challenges,
                             $training_lessons_learned, $youtube_result_video, $moodle_url, $ready_to_show, $show_report, $show_signup_count, $featured_description, $community_id,
-                            $zoom_link, $zoom_link_full, $feature_photo1_main, $feature_photo1_tmb, $feature_photo2_main, $feature_photo2_tmb, $feature_photo3_main, $feature_photo3_tmb, $registration_scope, $trainer_contact_email);
+                            $zoom_link, $zoom_link_full, $earthcal_event_url, $feature_photo1_main, $feature_photo1_tmb, $feature_photo2_main, $feature_photo2_tmb, $feature_photo3_main, $feature_photo3_tmb, $registration_scope, $trainer_contact_email);
     $stmt_fetch->fetch();
     $stmt_fetch->close();
 }
@@ -471,8 +472,18 @@ if (!empty($community_id)) {
     <div class="form-item">
         <label for="zoom_link_full">Zoom Link Full:</label><br>
         <textarea id="zoom_link_full" name="zoom_link_full" class="form-field-style"><?php echo htmlspecialchars($zoom_link_full ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>
+       <p class="form-caption">
+           Paste the full Zoom link with as much accompanying text as you think appropriate.
+       </p>
+   </div>
+
+    <!-- ======================= Earthcal Event Link ======================= -->
+    <div class="form-item">
+        <label for="earthcal_event_url">📆 Earthcal Event Link</label><br>
+        <input type="url" id="earthcal_event_url" name="earthcal_event_url" class="form-field-style"
+               value="<?php echo htmlspecialchars($earthcal_event_url ?? '', ENT_QUOTES, 'UTF-8'); ?>">
         <p class="form-caption">
-            Paste the full Zoom link with as much accompanying text as you think appropriate.
+            Grab a Share-Event-Link from your Earthcal so that participants can easily add this training to their personal calendars
         </p>
     </div>
 

--- a/en/launch-training_process.php
+++ b/en/launch-training_process.php
@@ -64,6 +64,7 @@ $zoom_link = trim($_POST['zoom_link'] ?? '');
 $zoom_link_full = trim($_POST['zoom_link_full'] ?? '');
 $registration_scope = trim($_POST['registration_scope'] ?? '');
 $trainer_contact_email = trim($_POST['trainer_contact_email'] ?? '');
+$earthcal_event_url = trim($_POST['earthcal_event_url'] ?? '');
 
 $cost = isset($_POST["cost"]) ? intval($_POST["cost"]) : null;
 $currency = trim($_POST["currency"] ?? "");
@@ -127,19 +128,19 @@ if ($editing) {
             training_location=?, training_summary=?, training_agenda=?,
             training_success=?, training_challenges=?, training_lessons_learned=?,
             youtube_result_video=?, moodle_url=?, ready_to_show=?, show_report=?, show_signup_count=?, featured_description=?, community_id=?,
-            zoom_link=?, zoom_link_full=?, registration_scope=?, trainer_contact_email=?, cost=?, currency=?, display_cost=?
+            zoom_link=?, zoom_link_full=?, registration_scope=?, trainer_contact_email=?, earthcal_event_url=?, cost=?, currency=?, display_cost=?
             WHERE training_id=?";
     $stmt = $gobrik_conn->prepare($sql);
     if (!$stmt) {
         echo json_encode(['success' => false, 'error' => 'Statement preparation failed.']);
         exit();
     }
-    $stmt->bind_param("sssississiissssssssiiisissssissi",
+    $stmt->bind_param("sssississiissssssssiiisisssssissi",
         $training_title, $training_subtitle, $lead_trainer, $country_id, $training_date, $training_time_txt, $no_participants,
         $training_type, $training_language, $briks_made, $avg_brik_weight, $training_location,
         $training_summary, $training_agenda, $training_success, $training_challenges,
         $training_lessons_learned, $youtube_result_video, $moodle_url, $ready_to_show, $show_report, $show_signup_count,
-        $featured_description, $community_id, $zoom_link, $zoom_link_full, $registration_scope, $trainer_contact_email, $cost, $currency, $display_cost,
+        $featured_description, $community_id, $zoom_link, $zoom_link_full, $registration_scope, $trainer_contact_email, $earthcal_event_url, $cost, $currency, $display_cost,
         $training_id
     );
     if ($stmt->execute()) {
@@ -175,19 +176,19 @@ if ($editing) {
             (training_title, training_subtitle, lead_trainer, country_id, training_date, training_time_txt, no_participants,
             training_type, training_language, briks_made, avg_brik_weight, training_location, training_summary, training_agenda, training_success, training_challenges,
             training_lessons_learned, youtube_result_video, moodle_url, ready_to_show, show_report, show_signup_count, featured_description, community_id,
-            zoom_link, zoom_link_full, registration_scope, trainer_contact_email, cost, currency, display_cost)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            zoom_link, zoom_link_full, registration_scope, trainer_contact_email, earthcal_event_url, cost, currency, display_cost)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     $stmt = $gobrik_conn->prepare($sql);
     if (!$stmt) {
         echo json_encode(['success' => false, 'error' => 'Statement preparation failed.']);
         exit();
     }
-    $stmt->bind_param("sssississiissssssssiiisissssiss",
+    $stmt->bind_param("sssississiissssssssiiisisssssiss",
         $training_title, $training_subtitle, $lead_trainer, $country_id, $training_date, $training_time_txt, $no_participants,
         $training_type, $training_language, $briks_made, $avg_brik_weight, $training_location,
         $training_summary, $training_agenda, $training_success, $training_challenges,
         $training_lessons_learned, $youtube_result_video, $moodle_url, $ready_to_show, $show_report, $show_signup_count, $featured_description, $community_id,
-        $zoom_link, $zoom_link_full, $registration_scope, $trainer_contact_email, $cost, $currency, $display_cost
+        $zoom_link, $zoom_link_full, $registration_scope, $trainer_contact_email, $earthcal_event_url, $cost, $currency, $display_cost
     );
     if ($stmt->execute()) {
         $new_training_id = $gobrik_conn->insert_id;


### PR DESCRIPTION
## Summary
- allow setting an Earthcal event link when launching a training
- store earthcal_event_url in launch-training process

## Testing
- `php -l en/launch-training.php`
- `php -l en/launch-training_process.php`


------
https://chatgpt.com/codex/tasks/task_e_687ccfc64ecc832bbd657ed21a89bcc6