### PR TITLE
Fix training status toggle and delete path

### DIFF
--- a/api/toggle_training_status.php
+++ b/api/toggle_training_status.php
@@ -1,0 +1,35 @@
+<?php
+require_once '../earthenAuth_helper.php';
+require_once '../gobrikconn_env.php';
+
+header('Content-Type: application/json');
+
+if (!isLoggedIn()) {
+    echo json_encode(['success' => false, 'error' => 'not_logged_in']);
+    exit();
+}
+
+$training_id = isset($_POST['training_id']) ? intval($_POST['training_id']) : 0;
+$show_report = isset($_POST['show_report']) ? intval($_POST['show_report']) : null;
+
+if ($training_id <= 0 || !in_array($show_report, [0,1], true)) {
+    echo json_encode(['success' => false, 'error' => 'invalid_params']);
+    exit();
+}
+
+$stmt = $gobrik_conn->prepare("UPDATE tb_trainings SET show_report = ? WHERE training_id = ?");
+if (!$stmt) {
+    echo json_encode(['success' => false, 'error' => 'db']);
+    exit();
+}
+$stmt->bind_param('ii', $show_report, $training_id);
+$success = $stmt->execute();
+$stmt->close();
+$gobrik_conn->close();
+
+if ($success) {
+    echo json_encode(['success' => true, 'show_report' => $show_report]);
+} else {
+    echo json_encode(['success' => false, 'error' => 'query']);
+}
+?>

--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -69,7 +69,7 @@ $locationFullTxt = $location_third_last . ', ' . $location_last;
 
 // 🎓 Fetch trainings where user is trainer
 $trainings = [];
-$sql_trainings = "SELECT t.training_id, t.training_title, t.training_date, t.training_location, t.training_type, t.ready_to_show,
+$sql_trainings = "SELECT t.training_id, t.training_title, t.training_date, t.training_location, t.training_type, t.ready_to_show, t.show_report,
                          (SELECT COUNT(*) FROM tb_training_trainees WHERE training_id = t.training_id) AS trainee_count
                   FROM tb_trainings t
                   INNER JOIN tb_training_trainers tt ON t.training_id = tt.training_id
@@ -262,9 +262,12 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
                         </a>
                     </td>
 
-                    <!-- Status column showing publication status -->
+                    <!-- Status column with show_report toggle -->
                     <td style="text-align:center;">
-                        <?php echo ($training['ready_to_show'] == 1) ? '🟢' : '⚪'; ?>
+                        <label class="toggle-switch">
+                            <input type="checkbox" class="training-status-toggle" data-training-id="<?php echo $training['training_id']; ?>" <?php echo ($training['show_report'] == 1) ? 'checked' : ''; ?>>
+                            <span class="slider"></span>
+                        </label>
                     </td>
 
                     <!-- Actions column -->
@@ -1182,7 +1185,7 @@ function copyCourseListingURL(trainingId, button) {
 
 function deleteTraining(trainingId) {
     if (confirm('Are you sure you want to delete this training? This cannot be undone.')) {
-        fetch('process/delete_training.php', {
+        fetch('processes/delete_training.php', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
@@ -1206,6 +1209,35 @@ function deleteTraining(trainingId) {
         });
     }
 }
+
+// Toggle show_report status for trainings
+document.querySelectorAll('.training-status-toggle').forEach(function(toggle) {
+    toggle.addEventListener('change', function() {
+        const trainingId = this.dataset.trainingId;
+        const showReport = this.checked ? 1 : 0;
+        fetch('api/toggle_training_status.php', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({
+                'training_id': trainingId,
+                'show_report': showReport
+            })
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (!data.success) {
+                alert('Error updating status: ' + data.error);
+                toggle.checked = !toggle.checked; // revert on failure
+            }
+        })
+        .catch(() => {
+            alert('There was an error processing your request.');
+            toggle.checked = !toggle.checked;
+        });
+    });
+});
 
 
 


### PR DESCRIPTION
## Summary
- add show_report to My Trainings query
- use a toggle switch for training status with AJAX
- wire up new `api/toggle_training_status.php`
- correct delete training path

## Testing
- `php -l api/toggle_training_status.php`
- `php -l en/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68863f4f384c832b8c5756b0605c2f19