### PR TITLE
Fix My Trainings status logic

### DIFF
--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -248,18 +248,22 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
                 <?php
                     $training_date_ts = strtotime($training['training_date']);
                     $is_listed = $training['ready_to_show'] == 1;
-                    if ($is_listed && $training_date_ts < time()) {
-                        $circle = '🟢';
-                    } elseif ($is_listed && $training_date_ts > time()) {
+
+                    if (!$is_listed) {
+                        // Not listed yet
+                        $circle = '⚪';
+                    } elseif ($training_date_ts > time()) {
+                        // Listed and upcoming
                         $circle = '🔴';
+                    } else {
+                        // Listed and in the past
+                        $circle = '🟢';
                         if (!isset($pendingReport)) {
                             $pendingReport = [
                                 'id' => $training['training_id'],
                                 'title' => $training['training_title']
                             ];
                         }
-                    } else {
-                        $circle = '⚪';
                     }
                 ?>
                 <tr>


### PR DESCRIPTION
## Summary
- fix datatable logic for status circles
- display the report reminder only when a past training exists

## Testing
- `php -l en/dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_68885fdd2a6c832bbfee38cf01e41abc