### PR TITLE
Fix training status icons

### DIFF
--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -248,15 +248,19 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
                 <?php
                     $training_date_ts = strtotime($training['training_date']);
                     $is_listed = $training['ready_to_show'] == 1;
+                    $show_report = $training['show_report'] == 1;
 
                     if (!$is_listed) {
-                        // Not listed yet
+                        // Training not listed yet
                         $circle = '⚪';
+                    } elseif ($show_report) {
+                        // Report complete and public
+                        $circle = '✅';
                     } elseif ($training_date_ts > time()) {
                         // Listed and upcoming
                         $circle = '🟢';
                     } else {
-                        // Listed and in the past
+                        // Listed, past and no report yet
                         $circle = '🔴';
                         if (!isset($pendingReport)) {
                             $pendingReport = [


### PR DESCRIPTION
## Summary
- refactor My Trainings icon logic to display status based on training date and report status
- show report completion reminder when past trainings have no report

## Testing
- `php -l en/dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_688882c27070832b857a113da838c95c