### PR TITLE
Update trainer dashboard notice and table

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -2884,3 +2884,14 @@ padding: 10px;
 
 /* Material Design theme for DataTables */
 @import url('https://cdn.datatables.net/plug-ins/1.13.5/integration/material/dataTables.material.min.css');
+
+/* Dashboard trainer table mobile adjustments */
+@media screen and (max-width: 769px) {
+    #trainer-trainings td:nth-child(2),
+    #trainer-trainings th:nth-child(2) {
+        display: none;
+    }
+    #trainer-trainings td:nth-child(1) {
+        white-space: normal;
+    }
+}


### PR DESCRIPTION
## Summary
- update training status emoji logic for trainer table
- improve table display on mobile and allow training name wrapping
- show trainer report alert in top notice instead of modal
- add CSS to hide date column on small screens

## Testing
- `php -l en/dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_688981784ff0832baf1f0b640e4eada0