### PR TITLE
Improve dashboard modals and community search

### DIFF
--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -279,14 +279,17 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
 
                     <!-- Updated Signups Column -->
                     <td style="text-align:center;padding:10px;">
-                        <a href="javascript:void(0);" class="log-report-btn" onclick="openTraineesModal(<?php echo $training['training_id']; ?>, '<?php echo htmlspecialchars($training['training_title'], ENT_QUOTES, 'UTF-8'); ?>')" style="display:inline-block;">
-                            <?php echo (int) $training['trainee_count']; ?> 👥
+                        <a href="javascript:void(0);" class="log-report-btn signup-btn" onclick="openTraineesModal(<?php echo $training['training_id']; ?>, '<?php echo htmlspecialchars($training['training_title'], ENT_QUOTES, 'UTF-8'); ?>')" style="display:inline-block;">
+                            <?php echo (int) $training['trainee_count']; ?>
+                            <span class="default-emoji">👥</span><span class="hover-emoji">🔍</span>
                         </a>
                     </td>
 
                     <!-- Actions column -->
                     <td style="text-align:center;">
-                        <button class="serial-button settings-button" onclick="actionsTrainingModal(<?php echo $training['training_id']; ?>)">⚙️</button>
+                        <button class="serial-button settings-button" onclick="actionsTrainingModal(<?php echo $training['training_id']; ?>)">
+                            <span class="default-emoji">✏️</span><span class="hover-emoji">⚙️</span>
+                        </button>
                     </td>
                 </tr>
             <?php endforeach; ?>
@@ -1140,12 +1143,10 @@ function deleteEcobrick(serial_no) {
 function actionsTrainingModal(trainingId) {
     const modal = document.getElementById('form-modal-message');
     const modalBox = document.getElementById('modal-content-box');
-    let messageContainer = document.querySelector('.modal-message');
-    if (!messageContainer) {
-        messageContainer = document.createElement('div');
-        messageContainer.className = 'modal-message';
-        modalBox.appendChild(messageContainer);
-    }
+    modalBox.innerHTML = '';
+    const messageContainer = document.createElement('div');
+    messageContainer.className = 'modal-message';
+    modalBox.appendChild(messageContainer);
 
     let url = `register.php?id=${trainingId}`;
     let content = '';

--- a/includes/dashboard-inc.php
+++ b/includes/dashboard-inc.php
@@ -38,6 +38,16 @@ margin-top:-100px !important;
     color: white;
 }
 
+.signup-btn .hover-emoji {
+    display: none;
+}
+.signup-btn:hover .default-emoji {
+    display: none;
+}
+.signup-btn:hover .hover-emoji {
+    display: inline;
+}
+
 
 
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -2749,6 +2749,27 @@ position:relative;
 /* Use a pencil icon for settings buttons */
 .serial-button.settings-button::before {
     content: "✏️";
+    opacity: 1;
+}
+
+.serial-button.settings-button:hover::before {
+    content: "⚙️";
+}
+
+.serial-button.settings-button .hover-emoji {
+    display: none;
+}
+
+.serial-button.settings-button:hover .default-emoji {
+    display: none;
+}
+
+.serial-button.settings-button:hover .hover-emoji {
+    display: inline;
+}
+
+.serial-button.settings-button:hover span {
+    opacity: 1;
 }
 
 


### PR DESCRIPTION
## Summary
- clear action modal contents before reuse and update icons
- add hover icons for signups and action buttons
- add dynamic community caption and autocomplete behaviour
- export country and language data to JS
- add shared community helper functions

## Testing
- `php -l en/dashboard.php`
- `php -l en/launch-training.php`
- `php -l includes/dashboard-inc.php`
- `node --check scripts/core-2025.js`


------
https://chatgpt.com/codex/tasks/task_e_68898b7b106c832bb186664b7700d575