### PR TITLE
Fix add community modal for training pages

### DIFF
--- a/en/finalize.php
+++ b/en/finalize.php
@@ -438,7 +438,7 @@ function addCommunity2Buwana(event) {
     const form = document.getElementById('addCommunityForm');
     const formData = new FormData(form);
 
-    fetch('../scripts/add_community.php', {
+    fetch('https://buwana.ecobricks.org/api/add_community.php', {
         method: 'POST',
         body: formData
     })

--- a/en/finalizer.php
+++ b/en/finalizer.php
@@ -460,7 +460,7 @@ function addCommunity2Buwana(event) {
     const form = document.getElementById('addCommunityForm');
     const formData = new FormData(form);
 
-    fetch('../scripts/add_community.php', {
+    fetch('https://buwana.ecobricks.org/api/add_community.php', {
         method: 'POST',
         body: formData
     })

--- a/en/launch-training.php
+++ b/en/launch-training.php
@@ -697,7 +697,7 @@ document.addEventListener("DOMContentLoaded", function() {
         const query = communityNameInput.value.trim();
         communityIdInput.value = "";
         if (query.length >= 3) {
-            fetch(`../api/search_communities.php?query=${encodeURIComponent(query)}`)
+            fetch(`https://buwana.ecobricks.org/api/api/search_communities_by_id.php?query=${encodeURIComponent(query)}`)
                 .then(res => res.json())
                 .then(list => showCommunitySuggestions(list, suggestionsBox, communityNameInput, communityIdInput))
                 .catch(err => console.error('Error loading communities:', err));

--- a/en/training-report.php
+++ b/en/training-report.php
@@ -462,7 +462,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
     function fetchCommunities(query) {
         if (query.length >= 3) {
-            fetch(`../api/search_communities.php?query=${encodeURIComponent(query)}`)
+            fetch(`https://buwana.ecobricks.org/api/api/search_communities_by_id.php?query=${encodeURIComponent(query)}`)
                 .then(response => response.json())
                 .then(data => {
                     resultsDiv.innerHTML = "";
@@ -751,7 +751,7 @@ function addCommunity2Buwana(event) {
     const form = document.getElementById('addCommunityForm');
     const formData = new FormData(form);
 
-    fetch('../scripts/add_community.php', {
+    fetch('https://buwana.ecobricks.org/api/add_community.php', {
         method: 'POST',
         body: formData
     })

--- a/scripts/core-2025.js
+++ b/scripts/core-2025.js
@@ -561,7 +561,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const form = document.getElementById('addCommunityForm');
         const formData = new FormData(form);
 
-        fetch('../scripts/add_community.php', {
+        fetch('https://buwana.ecobricks.org/api/add_community.php', {
             method: 'POST',
             body: formData
         })
@@ -574,7 +574,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 const communityIdInput = document.getElementById('community_id');
                 if (communityInput) communityInput.value = data.community_name;
                 if (communityIdInput) {
-                    fetch('../api/search_communities.php?query=' + encodeURIComponent(data.community_name))
+                    fetch('https://buwana.ecobricks.org/api/api/search_communities_by_id.php?query=' + encodeURIComponent(data.community_name))
                         .then(r => r.json())
                         .then(list => {
                             const match = list.find(c => c.com_name === data.community_name);


### PR DESCRIPTION
## Summary
- use Buwana API endpoints when adding a community
- update community search autocomplete to use Buwana API

## Testing
- `php -l en/launch-training.php`
- `php -l en/finalizer.php`
- `php -l en/training-report.php`
- `php -l en/finalize.php`
- `node --check scripts/core-2025.js`

------
https://chatgpt.com/codex/tasks/task_e_688992c757ac832bb87283435bf15601