### PR TITLE
Fix training image submission layout

### DIFF
--- a/en/add-training-images.php
+++ b/en/add-training-images.php
@@ -273,13 +273,12 @@ $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobri
 
   <!-- PAGE CONTENT-->
 
-    <div id="form-submission-box">
+    <div id="form-submission-box" class="landing-page-form" style="height:auto !important">
         <div class="form-container">
             <div class="form-top-header" style="display:flex;flex-flow:row;">
-                <div class="step-graphic" style="width:fit-content;margin:auto;margin-left:0px">
+                <div class="step-graphic" style="width:fit-content;margin:auto;">
                     <img src="../svgs/step2-log-project.svg" style="height:25px;">
                 </div>
-                <div id="language-code" onclick="showLangSelector()" aria-label="Switch languages"><span data-lang-id="000-language-code">🌐 EN</span></div>
             </div>
 
             <div class="splash-form-content-block">
@@ -358,7 +357,7 @@ $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobri
     <?php endfor; ?>
 
     <div data-lang-id="013-submit-upload-button">
-        <input type="submit" value="⬆️ Upload Photos" id="upload-progress-button" aria-label="Submit photos for upload">
+        <input type="submit" value="💾 Save Report" id="upload-progress-button" aria-label="Submit photos for upload">
     </div>
 
 </form> <!-- ✅ FORM ENDS HERE -->
@@ -450,11 +449,16 @@ document.querySelector('#photoform').addEventListener('submit', function(event) 
     var formData = new FormData(form);
     var fileSelected = false;
     var deletedImages = [];
+    var hasExistingImages = false;
 
     // ✅ Check for selected or deleted images
     for (var i = 0; i <= 6; i++) {
         var fileInput = document.getElementById(`training_photo${i}_main`);
         var clearButton = document.getElementById(`clear-btn-${i}`);
+
+        if (fileInput && fileInput.getAttribute("data-has-image") === "true") {
+            hasExistingImages = true;
+        }
 
         if (fileInput && fileInput.files.length > 0) {
             fileSelected = true; // ✅ A file is selected
@@ -464,7 +468,7 @@ document.querySelector('#photoform').addEventListener('submit', function(event) 
     }
 
     // ✅ If no file is selected and no image was deleted, prevent submission
-    if (!fileSelected && deletedImages.length === 0) {
+    if (!fileSelected && deletedImages.length === 0 && !hasExistingImages) {
         showFormModal(chooseFileMessage);
         button.innerHTML = originalButtonText; // Restore button text
         button.disabled = false; // Enable button
@@ -692,6 +696,13 @@ function uploadSuccess(data) {
         }
 
     </script>
+
+    <br><br>
+    </div> <!--closes main-->
+
+    <!--FOOTER STARTS HERE-->
+    <?php require_once ("../footer-2025.php");?>
+    </div>
 
     </body>
 </html>

--- a/includes/add-training-inc.php
+++ b/includes/add-training-inc.php
@@ -257,6 +257,7 @@ input[type="submit"]:hover {
   z-index: 20;
   font-family: "Mulish", sans-serif;
   position: relative;
+  padding-top: 0;
 
 }
 
@@ -269,6 +270,7 @@ input[type="submit"]:hover {
     padding: 20px 20px 0 20px;
     max-width: 600px;
     padding: 20px;
+    padding-top: 0;
     position: relative;
     margin-top: 60px;
 
@@ -302,6 +304,7 @@ input[type="submit"]:hover {
     margin-top: auto;
     margin-bottom: auto;
     padding: 30px;
+    padding-top: 0;
     margin-top: 100px;
 
   }


### PR DESCRIPTION
## Summary
- center header graphics, drop language code
- adjust form box to mimic layout of log.php
- allow save with existing images and rename submit button
- close `#main` properly after form and include footer
- remove top padding from training forms

## Testing
- `php -l en/add-training-images.php`
- `php -l includes/add-training-inc.php`
- `php -l en/training-report.php`

------
https://chatgpt.com/codex/tasks/task_e_6889bf148e18832b8ffe770f5706e3ed