### PR TITLE
Fix training-report translation keys

### DIFF
--- a/en/training-report.php
+++ b/en/training-report.php
@@ -237,7 +237,7 @@ $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobri
         </div>
 
     <div class="form-item">
-        <label for="training_subtitle">Add an optional subtitle to your training...</label><br>
+        <label for="training_subtitle" data-lang-id="025-title-subtitle">Add an optional subtitle to your training...</label><br>
         <input type="text" id="training_subtitle" name="training_subtitle"
                value="<?php echo htmlspecialchars($training_subtitle ?? '', ENT_QUOTES, 'UTF-8'); ?>"
                aria-label="Training Subtitle">
@@ -263,7 +263,7 @@ $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobri
     </div>
 
     <div class="form-item">
-    <label for="training_date" datal-lang-id="006-title-date">Training Date:</label><br>
+    <label for="training_date" data-lang-id="006-title-date">Training Date:</label><br>
     <input type="datetime-local" id="training_date" name="training_date"
     value="<?php echo isset($training_date) ? date('Y-m-d\TH:i', strtotime($training_date)) : date('Y-m-d\T12:00'); ?>"
     aria-label="Training Date"  class="form-field-style">
@@ -459,8 +459,8 @@ $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobri
     <!-- ======================= Show Report Toggle ======================= -->
     <div class="form-row" style="display:flex;flex-flow:row;background-color:var(--lighter);padding:20px;border:grey 1px solid;border-radius:12px;margin-top:20px;">
         <div id="left-colum" style="width: 100%;">
-            <label>🚀 Publish this training publicly?</label>
-            <p class="form-caption" style="margin-top:10px;">Display the final training report of this training on ecobricks.org</p>
+            <label data-lang-id="024-title-show">🚀 Publish this training?</label>
+            <p class="form-caption" style="margin-top:10px;" data-lang-id="024-show-caption">Display the final training report of this training on ecobricks.org</p>
         </div>
 
         <div id="right-column" style="width:100px; justify-content:center;">
@@ -479,7 +479,7 @@ $og_image = !empty($feature_photo1_main) ? $feature_photo1_main : "https://gobri
 <!--     <input type="hidden" id="lon" name="longitude" value="<?php echo htmlspecialchars($longitude ?? '', ENT_QUOTES, 'UTF-8'); ?>"> -->
 <?php if ($editing): ?>
 <div>
-    <button type='submit' id='save-progress' class='confirm-button' style='background:grey;width: 100%;margin: 30px 0px -15px 0px;'>💾 Save Progress</button>
+    <button type='submit' id='save-progress' class='confirm-button' data-lang-id='099-save-progress' style='background:grey;width: 100%;margin: 30px 0px -15px 0px;'>💾 Save Progress</button>
 </div>
 <?php endif; ?>
 

--- a/translations/training-report-en.js
+++ b/translations/training-report-en.js
@@ -13,11 +13,14 @@ const en_Page_Translations = {
     "004-form-description-post": "Is your workshop, event or training complete?  Share your social success with the world! Use this form to file and post your completed event or training report. Trainings will be featured on our main page and archived in our trainings database.",
     "005-title-title":"Training Title:",
     "005-training-give-title": "Give your training a title.  This will be how your report is featured.",
+    "025-title-subtitle": "Add an optional subtitle to your training...",
     "006-title-date":"Training Date:",
     "006-training-date":"On what date and time did this training run?",
     "007-title-participants": "Number of Participants:",
     "007-training-count": "How many people participated (including trainers)?",
     "008-lead-trainer": "Lead Trainer:",
+    "005b-title-trainers": "Who are the trainers leading this training?",
+    "005b-trainers-caption": "Select the trainers leading this training.",
     "008-training-trainers": "Who led the training? You can write multiple names here if you want. i.e. Lucie Mann and Ani Himawati",
     "009-title-community": "Trained Community:",
     "008-community-trained": "What community was this training for? Start typing to see and select a GoBrik community. <a href=\"#\" onclick=\"openAddCommunityModal(); return false;\" style=\"color: #007BFF; text-decoration: underline;\">Don't see your community? Add it.</a>",
@@ -49,8 +52,10 @@ const en_Page_Translations = {
     "022-moodle-caption": "Was there a Moodle course created for this training on learning.ecobricks.org? If so, include the URL here.",
     "023-title-youtube": "YouTube Video URL:",
     "023-training-youtube": "Was a YouTube video of this training posted? If so, include the URL here please.",
-    "024-title-show": "🚀 Publish this training publicly?",
+    "024-title-show": "🚀 Publish this training?",
+    "024-show-caption": "Display the final training report of this training on ecobricks.org",
     "022-training-show": "Is this training ready to be displayed on ecobricks.org? If so, we'll post the completed workshop to the live feed of GEA trainings. Don't worry, you can always come back here to edit the live listing!",
+    "099-save-progress": "💾 Save Progress",
     "100-submit-report-1": "Next: Upload Photos ➡️"
 };
 

--- a/translations/training-report-es.js
+++ b/translations/training-report-es.js
@@ -12,11 +12,14 @@ const es_Page_Translations = {
     "004-form-description-post": "¿Ha finalizado tu taller, evento o capacitación? ¡Comparte tu éxito social con el mundo! Usa este formulario para enviar y publicar tu informe de evento o capacitación completado. Las formaciones se destacarán en nuestra página principal y se archivarán en nuestra base de datos de formaciones.",
     "005-title-title": "Título de la capacitación:",
     "005-training-give-title": "Dale un título a tu capacitación. Así se mostrará tu informe.",
+    "025-title-subtitle": "Agrega un subtítulo opcional a tu capacitación...",
     "006-title-date": "Fecha de la capacitación:",
     "006-training-date": "¿En qué fecha y hora se llevó a cabo esta capacitación?",
     "007-title-participants": "Número de participantes:",
     "007-training-count": "¿Cuántas personas participaron (incluidos los formadores)?",
     "008-lead-trainer": "Formador principal:",
+    "005b-title-trainers": "¿Quiénes son los formadores que lideran esta capacitación?",
+    "005b-trainers-caption": "Selecciona los formadores que lideran esta capacitación.",
     "008-training-trainers": "¿Quién dirigió la capacitación? Puedes escribir varios nombres aquí si es necesario, por ejemplo, Lucie Mann y Ani Himawati.",
     "009-title-community": "Comunidad capacitada:",
     "008-community-trained": "¿Para qué comunidad fue esta capacitación? Empieza a escribir para ver y seleccionar una comunidad de GoBrik. <a href=\"#\" onclick=\"openAddCommunityModal(); return false;\" style=\"color: #007BFF; text-decoration: underline;\">¿No ves tu comunidad? Agrégala.</a>",
@@ -28,6 +31,9 @@ const es_Page_Translations = {
     "012-training-average": "¿No se hicieron ecoladrillos en esta capacitación? Simplemente pon \"0\".",
     "013-title-country": "País:",
     "013-training-country": "¿Dónde se realizó esta capacitación? Si fue en línea, selecciona el país del formador principal.",
+    "024-title-show": "🚀 ¿Publicar esta capacitación?",
+    "024-show-caption": "Mostrar el informe final de esta capacitación en ecobricks.org",
+    "099-save-progress": "💾 Guardar progreso",
     "100-submit-report-1": "Siguiente: Subir fotos ➡️"
 };
 

--- a/translations/training-report-fr.js
+++ b/translations/training-report-fr.js
@@ -13,11 +13,14 @@ const fr_Page_Translations = {
     "004-form-description-post": "Votre atelier, événement ou formation est-il terminé ? Partagez votre succès social avec le monde ! Utilisez ce formulaire pour soumettre et publier le rapport de votre événement ou formation complété. Les formations seront mises en avant sur notre page principale et archivées dans notre base de données des formations.",
     "005-title-title": "Titre de la formation :",
     "005-training-give-title": "Donnez un titre à votre formation. C'est ainsi que votre rapport sera présenté.",
+    "025-title-subtitle": "Ajoutez un sous-titre optionnel à votre formation...",
     "006-title-date": "Date de la formation :",
     "006-training-date": "À quelle date et à quelle heure cette formation a-t-elle eu lieu ?",
     "007-title-participants": "Nombre de participants :",
     "007-training-count": "Combien de personnes ont participé (y compris les formateurs) ?",
     "008-lead-trainer": "Formateur principal :",
+    "005b-title-trainers": "Qui sont les formateurs dirigeant cette formation ?",
+    "005b-trainers-caption": "Sélectionnez les formateurs qui dirigent cette formation.",
     "008-training-trainers": "Qui a dirigé la formation ? Vous pouvez écrire plusieurs noms ici si nécessaire, par exemple, Lucie Mann et Ani Himawati.",
     "009-title-community": "Communauté formée :",
     "008-community-trained": "Pour quelle communauté cette formation a-t-elle été réalisée ? Commencez à taper pour voir et sélectionner une communauté GoBrik. <a href=\"#\" onclick=\"openAddCommunityModal(); return false;\" style=\"color: #007BFF; text-decoration: underline;\">Vous ne trouvez pas votre communauté ? Ajoutez-la.</a>",
@@ -49,8 +52,10 @@ const fr_Page_Translations = {
     "022-moodle-caption": "Un cours Moodle a-t-il été créé pour cette formation sur learning.ecobricks.org ? Si oui, incluez l'URL ici.",
     "023-title-youtube": "URL de la vidéo YouTube :",
     "023-training-youtube": "Une vidéo YouTube de cette formation a-t-elle été publiée ? Si oui, incluez l'URL ici.",
-    "024-title-show": "Publier cette formation publiquement ?",
+    "024-title-show": "🚀 Publier cette formation ?",
+    "024-show-caption": "Afficher le rapport final de cette formation sur ecobricks.org",
     "022-training-show": "Cette formation est-elle prête à être affichée sur ecobricks.org ? Si oui, nous publierons l'atelier complété sur le flux en direct des formations GEA. Ne vous inquiétez pas, vous pouvez toujours revenir ici pour modifier la liste affichée !",
+    "099-save-progress": "💾 Enregistrer la progression",
     "100-submit-report-1": "Suivant : Télécharger les photos ➡️"
 };
 

--- a/translations/training-report-id.js
+++ b/translations/training-report-id.js
@@ -13,11 +13,14 @@ const id_Page_Translations = {
     "004-form-description-post": "Apakah lokakarya, acara, atau pelatihan Anda telah selesai? Bagikan keberhasilan sosial Anda dengan dunia! Gunakan formulir ini untuk mengajukan dan mengunggah laporan acara atau pelatihan yang telah selesai. Pelatihan akan ditampilkan di halaman utama kami dan diarsipkan dalam database pelatihan kami.",
     "005-title-title": "Judul Pelatihan:",
     "005-training-give-title": "Beri judul pada pelatihan Anda. Ini akan menjadi cara laporan Anda ditampilkan.",
+    "025-title-subtitle": "Tambahkan subjudul opsional untuk pelatihan Anda...",
     "006-title-date": "Tanggal Pelatihan:",
     "006-training-date": "Pada tanggal dan waktu berapa pelatihan ini berlangsung?",
     "007-title-participants": "Jumlah Peserta:",
     "007-training-count": "Berapa banyak orang yang berpartisipasi (termasuk pelatih)?",
     "008-lead-trainer": "Pelatih Utama:",
+    "005b-title-trainers": "Siapa pelatih yang memimpin pelatihan ini?",
+    "005b-trainers-caption": "Pilih pelatih yang memimpin pelatihan ini.",
     "008-training-trainers": "Siapa yang memimpin pelatihan? Anda dapat menuliskan beberapa nama di sini jika diperlukan, misalnya, Lucie Mann dan Ani Himawati.",
     "009-title-community": "Komunitas yang Dilatih:",
     "008-community-trained": "Komunitas mana yang mengikuti pelatihan ini? Mulai mengetik untuk melihat dan memilih komunitas GoBrik. <a href=\"#\" onclick=\"openAddCommunityModal(); return false;\" style=\"color: #007BFF; text-decoration: underline;\">Tidak melihat komunitas Anda? Tambahkan.</a>",
@@ -49,8 +52,10 @@ const id_Page_Translations = {
     "022-moodle-caption": "Apakah ada kursus Moodle yang dibuat untuk pelatihan ini di learning.ecobricks.org? Jika ada, masukkan URL di sini.",
     "023-title-youtube": "URL Video YouTube:",
     "023-training-youtube": "Apakah ada video YouTube yang diposting tentang pelatihan ini? Jika ada, silakan masukkan URL di sini.",
-    "024-title-show": "Publikasikan pelatihan ini secara publik?",
+    "024-title-show": "🚀 Publikasikan pelatihan ini?",
+    "024-show-caption": "Tampilkan laporan akhir pelatihan ini di ecobricks.org",
     "022-training-show": "Apakah pelatihan ini siap ditampilkan di ecobricks.org? Jika ya, kami akan memposting lokakarya yang telah selesai ke umpan langsung pelatihan GEA. Jangan khawatir, Anda selalu dapat kembali ke sini untuk mengedit daftar yang ditampilkan!",
+    "099-save-progress": "💾 Simpan Progres",
     "100-submit-report-1": "Lanjut: Unggah Foto ➡️"
 };
 


### PR DESCRIPTION
## Summary
- add `data-lang-id` attributes for subtitle, trainer, date and publish sections
- translate missing strings in `training-report-xx.js` files
- fix text for publish label
- add save progress translations

## Testing
- `php -l en/training-report.php`


------
https://chatgpt.com/codex/tasks/task_e_6889caa82a00832b8e84cbc390a6e77c