### PR TITLE
Route logged-in users to dashboard from root index

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,3 +1,7 @@
+<?php
+session_start();
+$isLoggedIn = isset($_SESSION['buwana_user']) && isset($_SESSION['buwana_user']['jwt']);
+?>
 <!DOCTYPE html>
 <html>
 <head>
@@ -148,7 +152,8 @@ document.addEventListener('DOMContentLoaded', function() {
             langDir = 'en/';
         }
 
-        window.location.href = langDir;
+        const target = <?php echo $isLoggedIn ? "'dashboard.php'" : "'index.php'"; ?>;
+        window.location.href = langDir + target;
     }, 600); // 10 seconds
 });
 


### PR DESCRIPTION
## Summary
- Detect active Buwana session on the landing page
- Redirect authenticated visitors to their language dashboard
- Preserve language-based redirect for guests

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_689fefa2e234832bac85cedda1d115b1