### PR TITLE
Fix mobile alignment and sort trainings by date

### DIFF
--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -180,7 +180,7 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
 
         <!-- TRAINER TRAININGS -->
 <?php if (strpos(strtolower($gea_status), 'trainer') !== false): ?>
-        <div id="my-trainings-panel" class="dashboard-panel" style="text-align:center;width:100%;margin:auto;margin-top:25px;">
+        <div id="my-trainings-panel" class="dashboard-panel" style="text-align:center;width:100%;margin:25px auto 0;">
             <h3 data-lang-id="002-my-trainings">My Trainings</h3>
             <div class="menu-buttons-row">
                             <a href="launch-training.php" class="page-button" style="margin: 10px;">🚀 New Training</a>
@@ -674,6 +674,7 @@ $(document).ready(function() {
             }
         },
         "columnDefs": [
+            { "type": "date", "targets": 1 },
             { "orderable": false, "targets": [2, 3] }
         ]
     });

--- a/includes/dashboard-inc.php
+++ b/includes/dashboard-inc.php
@@ -257,6 +257,10 @@ margin-top:-100px !important;
     font-size: 0.9em;
 }
 
+#my-trainings-panel {
+    box-sizing: border-box;
+}
+
 /* Trainer trainings table tweaks */
 #trainer-trainings td:first-child {
     white-space: normal;


### PR DESCRIPTION
## Summary
- Ensure the My Trainings panel is centered on mobile devices by accounting for padding
- Sort trainer-managed trainings by date so the latest appear first

## Testing
- `php -l en/dashboard.php`
- `php -l includes/dashboard-inc.php`


------
https://chatgpt.com/codex/tasks/task_e_689ff8415484832b9f6f2893933053db