### PR TITLE
Add edit actions and delete modal to accounting page

### DIFF
--- a/includes/accounting-inc.php
+++ b/includes/accounting-inc.php
@@ -114,6 +114,17 @@
     color: white;          /* White text for contrast */
 }
 
+/* Styling for cancel button */
+.ecobrick-action-button.cancel-button {
+    background-color: grey;
+    color: white;
+}
+
+.ecobrick-action-button.cancel-button:hover {
+    background-color: #6e6e6e;
+    color: white;
+}
+
 
 
 #splash-bar {

--- a/processes/delete_transaction.php
+++ b/processes/delete_transaction.php
@@ -1,0 +1,30 @@
+<?php
+session_start();
+require_once '../gobrikconn_env.php';
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $cash_tran_id = $_POST['cash_tran_id'] ?? null;
+    if ($cash_tran_id) {
+        $sql = "DELETE FROM tb_cash_transaction WHERE cash_tran_id = ?";
+        $stmt = $gobrik_conn->prepare($sql);
+        if ($stmt) {
+            $stmt->bind_param('i', $cash_tran_id);
+            if ($stmt->execute()) {
+                echo json_encode(['success' => true]);
+            } else {
+                echo json_encode(['success' => false, 'error' => 'Failed to delete transaction: ' . $stmt->error]);
+            }
+            $stmt->close();
+        } else {
+            echo json_encode(['success' => false, 'error' => 'Failed to prepare statement: ' . $gobrik_conn->error]);
+        }
+    } else {
+        echo json_encode(['success' => false, 'error' => 'Invalid transaction ID provided']);
+    }
+} else {
+    echo json_encode(['success' => false, 'error' => 'Invalid request method']);
+}
+
+$gobrik_conn->close();
+?>


### PR DESCRIPTION
## Summary
- Add "Edit" column with ✏️ icon to accounting transactions table
- Introduce modal to delete cash transactions or cancel
- Display GEA logo in transaction detail modal and style cancel button

## Testing
- `php -l en/accounting.php`
- `php -l includes/accounting-inc.php`
- `php -l processes/delete_transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1ebcb9d4c832b8cca50a28f824c7c